### PR TITLE
Add openbmc/linux kernel recipe

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc.bb
@@ -1,0 +1,26 @@
+DESCRIPTION = "Linux kernel for OpenBMC"
+SECTION = "kernel"
+LICENSE = "GPLv2"
+
+KBRANCH ?= "dev"
+
+inherit kernel
+require recipes-kernel/linux/linux-yocto.inc
+
+SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
+SRC_URI += "file://obmc-bsp.scc \
+            file://obmc-bsp.cfg \
+            file://obmc-bsp-user-config.cfg \
+            file://obmc-bsp-user-patches.scc \
+           "
+
+LINUX_VERSION ?= "4.3-rc1"
+LINUX_VERSION_EXTENSION ?= "-openbmc"
+
+SRCREV="${AUTOREV}"
+
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+COMPATIBLE_MACHINE_${MACHINE} = "openbmc"
+
+S = "${WORKDIR}/git"

--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc/obmc-bsp-user-config.cfg
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc/obmc-bsp-user-config.cfg
@@ -1,0 +1,8 @@
+#
+# Used by yocto-kernel to manage config options.
+#
+# yocto-kernel may change the contents of this file in any
+# way it sees fit, including removing comments like this,
+# so don't manually make any modifications you don't want
+# to lose.
+#

--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc/obmc-bsp-user-patches.scc
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc/obmc-bsp-user-patches.scc
@@ -1,0 +1,8 @@
+#
+# Used by yocto-kernel to manage patches.
+#
+# yocto-kernel may change the contents of this file in any
+# way it sees fit, including removing comments like this,
+# so don't manually make any modifications you don't want
+# to lose.
+#

--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc/obmc-bsp.cfg
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc/obmc-bsp.cfg
@@ -1,0 +1,3 @@
+#
+# A convenient place to add config options, nothing more.
+#

--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc/obmc-bsp.scc
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc/obmc-bsp.scc
@@ -1,0 +1,17 @@
+#
+# The top-level 'feature' for the meta-obmc-bsp custom kernel.
+#
+# Essentially this is a convenient top-level container or starting
+# point for adding lower-level config fragements and features.
+#
+
+# meta-obmc-bsp.cfg in the linux-yocto-custom subdir is just a
+# convenient place for adding random config fragments.
+
+kconf hardware obmc-bsp.cfg
+
+# These are used by yocto-kernel to add config fragments and features.
+# Don't remove if you plan on using yocto-kernel with this BSP.
+
+kconf hardware obmc-bsp-user-config.cfg
+include obmc-bsp-user-patches.scc

--- a/meta-phosphor/common/recipes.txt
+++ b/meta-phosphor/common/recipes.txt
@@ -1,1 +1,3 @@
-recipes-phosphor      - Phosphor OpenBMC applications and configuration
+recipes-phosphor     - Phosphor OpenBMC applications and configuration
+recipes-kernel       - The kernel and generic applications/libraries with strong kernel dependencies
+recipes-connectivity - Libraries and applications related to communication with other devices 

--- a/meta-phosphor/conf/machine/include/obmc-bsp-common.inc
+++ b/meta-phosphor/conf/machine/include/obmc-bsp-common.inc
@@ -1,0 +1,14 @@
+#@TYPE: Machine
+#@NAME: OpenBMC
+#@DESCRIPTION: Common machine configuration for OpenBMC chips
+
+MACHINE_EXTRA_RRECOMMENDS = " kernel-modules"
+EXTRA_IMAGEDEPENDS += "u-boot"
+
+KERNEL_IMAGETYPE ?= "uImage"
+KERNEL_EXTRA_ARGS += "LOADADDR=${UBOOT_ENTRYPOINT}"
+
+UBOOT_SUFFIX ?= "bin"
+IMAGE_BOOT_FILES ?= "u-boot.${UBOOT_SUFFIX}"
+
+MACHINEOVERRIDES =. "openbmc:"


### PR DESCRIPTION
Added kernel recipe for openbmc/linux.
Add common machine metadata for all Phosphor BSPs.