### PR TITLE
Back off GCC to 4.9.3

### DIFF
--- a/meta-phosphor/conf/distro/openbmc-phosphor.conf
+++ b/meta-phosphor/conf/distro/openbmc-phosphor.conf
@@ -5,6 +5,7 @@ DISTRO_NAME = "Phosphor OpenBMC (Phosphor OpenBMC Project Reference Distro)"
 DISTRO_VERSION = "0.1.0"
 TARGET_VENDOR="-openbmc"
 
+GCCVERSION ?= "4.9.3"
 IMAGE_FSTYPES += "cpio.gz"
 IMAGE_LINGUAS = "en-us"
 


### PR DESCRIPTION
5.2.0 is producing an unusable kernel for Palmetto.
Qemuarm seems to work fine on either 5.2.0 or 4.9.3.
Remove when https://github.com/openbmc/openbmc/issues/10 is resolved.