### PR TITLE
Fix build break

### DIFF
--- a/meta-openbmc-bsp/meta-aspeed/meta-ast2400/recipes-kernel/linux/linux-obmc_%.bbappend
+++ b/meta-openbmc-bsp/meta-aspeed/meta-ast2400/recipes-kernel/linux/linux-obmc_%.bbappend
@@ -1,2 +1,2 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI += "file://defconfig hwmon.cfg"
+SRC_URI += "file://defconfig file://hwmon.cfg"


### PR DESCRIPTION
Missing a 'file://' in linux-obmc SRC_URI