### PR TITLE
Moving openbmc's ipmid and oem to support Nov1 release

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-oem.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-oem.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "libsystemd"
 
 SRC_URI += "git://github.com/openbmc/openpower-host-ipmi-oem"
 
-SRCREV = "f79a21f3c1e5209f3c911399c3b822ae93bb973d"
+SRCREV = "17160cebf1735337a35a12ba27728d90c5207ec5"
 
 FILES_${PN} += "${libdir}/host-ipmid/*.so"
 FILES_${PN}-dbg += "${libdir}/host-ipmid/.debug"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -14,7 +14,7 @@ inherit obmc-phosphor-c-daemon
 
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = "84a5a0a8fdb2a5df9e33ab9132f2c083eaa4b756"
+SRCREV = "5fc6492ff8882390e55592d776969a094567b0d5"
 
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Fixes contained up till now include...
host: 5fc6492ff8882390e55592d776969a094567b0d5
oem: 17160cebf1735337a35a12ba27728d90c5207ec5