### PR TITLE
Fix mkcimage task dependency in kernel-cuimage

### DIFF
--- a/meta-phosphor/classes/kernel-cuimage.bbclass
+++ b/meta-phosphor/classes/kernel-cuimage.bbclass
@@ -42,4 +42,4 @@ do_uboot_mkcimage() {
 	fi
 }
 
-addtask uboot_mkcimage before do_bundle_initramfs after do_compile
+addtask uboot_mkcimage before do_install after do_compile


### PR DESCRIPTION
The cuimage is used in the install task so it must be
generated by then.