### PR TITLE
out of tree device trees

### DIFF
--- a/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/conf/layer.conf
+++ b/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/conf/layer.conf
@@ -1,5 +1,9 @@
 # We have a conf and classes directory, add to BBPATH
 BBPATH .= ":${LAYERDIR}"
 
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
 BBFILE_COLLECTIONS += "palmetto"
 BBFILE_PATTERN_palmetto = ""

--- a/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/conf/machine/palmetto.conf
+++ b/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/conf/machine/palmetto.conf
@@ -1,5 +1,5 @@
 KMACHINE = "aspeed"
-KERNEL_DEVICETREE = "${KMACHINE}-bmc-opp-${MACHINE}.dtb"
+KERNEL_DEVICETREE = "${MACHINE}.dtb"
 
 require conf/machine/include/ast2400.inc
 require conf/machine/include/obmc-bsp-common.inc

--- a/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/recipes-kernel/linux/linux-obmc/palmetto.dts
+++ b/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/recipes-kernel/linux/linux-obmc/palmetto.dts
@@ -1,0 +1,325 @@
+/dts-v1/;
+
+#include "skeleton.dtsi"
+
+/ {
+	model = "Palmetto BMC";
+	compatible = "tyan,palmetto-bmc", "aspeed,ast2400";
+	#address-cells = <1>;
+	#size-cells = <1>;
+	interrupt-parent = <&vic>;
+
+	aliases {
+		serial0 = &uart5;
+	};
+
+	chosen {
+		stdout-path = &uart5;
+		bootargs = "console=ttyS4,38400";
+	};
+
+	memory {
+		reg = < 0x40000000 0x10000000 >;
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			compatible = "arm,arm926ej-s";
+			device_type = "cpu";
+			reg = <0>;
+		};
+	};
+
+	// FIXME
+	clocks {
+		// Do a proper driver... for now, we know the straps
+		// and uboot config on palmetto are:
+		// - CLKIN is 48Mhz
+		// - HPLL is 384Mhz
+		// - CPU:AHB is strapped 2:1
+		// - PCLK is HPLL/8 = 48Mhz
+		clk_apb: clk_apb {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <48000000>;
+		};
+		clk_hpll: clk_hpll {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <384000000>;
+		};
+	};
+
+	ahb {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		vic: interrupt-controller@1e6c0080 {
+			compatible = "aspeed,new-vic";
+	     		interrupt-controller;
+			#interrupt-cells = <1>;
+			valid-sources = < 0xffffffff 0x0007ffff>;
+			reg = <0x1e6c0080 0x80>;
+		};
+
+		mac0: ethernet@1e660000 {
+			compatible = "faraday,ftgmac100", "aspeed,ast2400-mac";
+			reg = <0x1e660000 0x180>;
+			interrupts = <2>;
+			use-nc-si;
+			no-hw-checksum;
+		};
+
+		apb {
+			compatible = "simple-bus";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			sram@1e72000 {
+				compatible = "mmio-sram";
+				reg = <0x1e72000 0x8000>;	// 32K
+			};
+
+			ibt@1e789140 {
+				compatible = "aspeed,bt-host";
+				reg = <0x1e789140 0x18>;
+			};
+
+			i2c: i2c@1e78a040 {
+				compatible = "aspeed,ast2400-i2c-common";
+				reg = <0x1e78a000 0x40>;
+				ranges = <0 0x1e78a000 0x1000>;
+				interrupts = <12>;
+				clocks = <&clk_apb>;
+
+				i2c0: i2c-bus@0x40 {
+					reg = <0x40 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <0>;
+					clock-frequency = <100000>;
+					status = "okay";
+					eeprom@50 {
+						compatible = "atmel,24c256";
+						reg = <0x50>;
+						pagesize = <64>;
+					};
+					rtc@68 {
+						compatible = "dallas,ds3231";
+						reg = <0x68>;
+						// interrupts = <GPIOF0>
+					};
+				};
+
+				i2c1: i2c-bus@0x80 {
+					reg = <0x80 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <1>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c2: i2c-bus@0xC0 {
+					reg = <0xC0 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <2>;
+					clock-frequency = <100000>;
+					status = "okay";
+					tmp423@4c {
+						compatible = "ti,tmp423";
+						reg = <0x4c>;
+					};
+				};
+
+				i2c3: i2c-bus@0x100 {
+					reg = <0x100 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <3>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c4: i2c-bus@0x140 {
+					reg = <0x140 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <4>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c5: i2c-bus@0x180 {
+					reg = <0x180 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <5>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c6: i2c-bus@0x1C0 {
+					reg = <0x1C0 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <6>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c7: i2c-bus@0x300 {
+					reg = <0x300 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <7>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c8: i2c-bus@0x340 {
+					reg = <0x340 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <8>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c9: i2c-bus@0x380 {
+					reg = <0x380 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <9>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+				i2c10: i2c-bus@0x3C0 {
+					reg = <0x380 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <10>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+				i2c11: i2c-bus@0x400 {
+					reg = <0x400 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <11>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+				i2c12: i2c-bus@0x440 {
+					reg = <0x400 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <12>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+				i2c13: i2c-bus@0x480 {
+					reg = <0x480 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <13>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+			};
+
+			syscon: syscon@1e6e2000 {
+				compatible = "aspeed,syscon", "syscon";
+				reg = <0x1e6e2000 0x1a8>;
+				interrupts = <19>;
+				clocks = <&clk_apb>;
+				status = "okay";
+			};
+
+			wdt: wdt@1e785000 {
+				compatible = "aspeed,wdt", "wdt";
+				reg = <0x1e785000 0x1c4>;
+				interrupts = <27>;
+				clocks = <&clk_apb>;
+			};
+
+			rtc: rtc@1e781000 {
+				compatible = "aspeed,rtc";
+				reg = <0x1e781000 0x18>;
+			};
+
+			timer: timer@98400000 {
+				compatible = "aspeed,timer";
+				reg = <0x1e782000 0x90>;
+				// The moxart_timer driver registers only one interrupt
+				// and assumes it's for timer 1
+				//interrupts = <16 17 18 35 36 37 38 39>;
+				interrupts = <16>;
+				clocks = <&clk_apb>;
+			};
+
+			gpio: gpio@1e780000 {
+			       compatible = "aspeed,ast2400-gpio";
+			       reg = <0x1e780000 0x1000>;
+			       interrupts = <20>;
+			};
+
+			uart1: serial@1e783000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e783000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <9>;
+			       clock-frequency = < 1843200 >;
+			       no-loopback-test;
+			};
+			uart2: serial@1e78d000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e78d000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <32>;
+			       clock-frequency = < 1843200 >;
+			       no-loopback-test;
+			};
+			/* APSS UART */
+			uart3: serial@1e78e000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e78e000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <33>;
+			       clock-frequency = < 1843200 >;
+			       no-loopback-test;
+			};
+
+			/* Host UART */
+			uart4: serial@1e78f000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e78f000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <34>;
+			       clock-frequency = < 1843200 >;
+			       current-speed = < 115200 >;
+			       no-loopback-test;
+			};
+#if 1
+			/* BMC UART */
+			uart5: serial@1e784000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e784000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <10>;
+			       clock-frequency = < 1843200 >;
+			       current-speed = < 38400 >;
+			       no-loopback-test;
+			};
+#endif
+
+			uart6: serial@1e787000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e787000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <10>;
+			       clock-frequency = < 1843200 >;
+			       current-speed = < 38400 >;
+			       no-loopback-test;
+			};
+		};
+	};
+};

--- a/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/recipes-kernel/linux/linux-obmc_%.bbappend
+++ b/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/recipes-kernel/linux/linux-obmc_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/linux-obmc:"
+SRC_URI += "file://palmetto.dts"

--- a/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/recipes.txt
+++ b/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/recipes.txt
@@ -1,0 +1,1 @@
+recipes-kernel       - The kernel and generic applications/libraries with strong kernel dependencies

--- a/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/conf/machine/barreleye.conf
+++ b/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/conf/machine/barreleye.conf
@@ -1,5 +1,5 @@
 KMACHINE = "aspeed"
-KERNEL_DEVICETREE = "${KMACHINE}-bmc-opp-palmetto.dtb"
+KERNEL_DEVICETREE = "${MACHINE}.dtb"
 
 require conf/machine/include/ast2400.inc
 require conf/machine/include/obmc-bsp-common.inc

--- a/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/recipes-kernel/linux/linux-obmc/barreleye.dts
+++ b/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/recipes-kernel/linux/linux-obmc/barreleye.dts
@@ -1,0 +1,333 @@
+/dts-v1/;
+
+#include "skeleton.dtsi"
+
+/ {
+	model = "Barrelye BMC";
+	compatible = "rackspace,barreleye-bmc", "aspeed,ast2400";
+	#address-cells = <1>;
+	#size-cells = <1>;
+	interrupt-parent = <&vic>;
+
+	aliases {
+		serial0 = &uart5;
+	};
+
+	chosen {
+		stdout-path = &uart5;
+		bootargs = "console=ttyS4,38400";
+	};
+
+	memory {
+		reg = < 0x40000000 0x10000000 >;
+	};
+
+	cpus {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		cpu@0 {
+			compatible = "arm,arm926ej-s";
+			device_type = "cpu";
+			reg = <0>;
+		};
+	};
+
+	// FIXME
+	clocks {
+		// Do a proper driver... for now, we know the straps
+		// and uboot config on palmetto are:
+		// - CLKIN is 48Mhz
+		// - HPLL is 384Mhz
+		// - CPU:AHB is strapped 2:1
+		// - PCLK is HPLL/8 = 48Mhz
+		clk_apb: clk_apb {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <48000000>;
+		};
+		clk_hpll: clk_hpll {
+			#clock-cells = <0>;
+			compatible = "fixed-clock";
+			clock-frequency = <384000000>;
+		};
+	};
+
+	ahb {
+		compatible = "simple-bus";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		vic: interrupt-controller@1e6c0080 {
+			compatible = "aspeed,new-vic";
+	     		interrupt-controller;
+			#interrupt-cells = <1>;
+			valid-sources = < 0xffffffff 0x0007ffff>;
+			reg = <0x1e6c0080 0x80>;
+		};
+
+		mac0: ethernet@1e660000 {
+			compatible = "faraday,ftgmac100", "aspeed,ast2400-mac";
+			reg = <0x1e660000 0x180>;
+			interrupts = <2>;
+			use-nc-si;
+			no-hw-checksum;
+		};
+
+		apb {
+			compatible = "simple-bus";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			ranges;
+
+			sram@1e72000 {
+				compatible = "mmio-sram";
+				reg = <0x1e72000 0x8000>;	// 32K
+			};
+
+			ibt@1e789140 {
+				compatible = "aspeed,bt-host";
+				reg = <0x1e789140 0x18>;
+			};
+
+			i2c: i2c@1e78a040 {
+				compatible = "aspeed,ast2400-i2c-common";
+				reg = <0x1e78a000 0x40>;
+				ranges = <0 0x1e78a000 0x1000>;
+				interrupts = <12>;
+				clocks = <&clk_apb>;
+
+				i2c0: i2c-bus@0x40 {
+					reg = <0x40 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <0>;
+					clock-frequency = <100000>;
+					status = "okay";
+					eeprom@50 {
+						compatible = "atmel,24c256";
+						reg = <0x50>;
+						pagesize = <64>;
+					};
+					rtc@68 {
+						compatible = "dallas,ds3231";
+						reg = <0x68>;
+						// interrupts = <GPIOF0>
+					};
+					lm75@4a {
+						compatible = "national,lm75";
+						reg = <0x4a>;
+					};
+				};
+
+				i2c1: i2c-bus@0x80 {
+					reg = <0x80 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <1>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c2: i2c-bus@0xC0 {
+					reg = <0xC0 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <2>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c3: i2c-bus@0x100 {
+					reg = <0x100 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <3>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c4: i2c-bus@0x140 {
+					reg = <0x140 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <4>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c5: i2c-bus@0x180 {
+					reg = <0x180 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <5>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c6: i2c-bus@0x1C0 {
+					reg = <0x1C0 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <6>;
+					clock-frequency = <100000>;
+					status = "okay";
+					nct7904@2d {
+						compatible = "nuvoton,nct7904";
+						reg = <0x2d>;
+					};
+					nct7904@2e {
+						compatible = "nuvoton,nct7904";
+						reg = <0x2e>;
+					};
+				};
+
+				i2c7: i2c-bus@0x300 {
+					reg = <0x300 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <7>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c8: i2c-bus@0x340 {
+					reg = <0x340 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <8>;
+					clock-frequency = <100000>;
+					status = "okay";
+				};
+
+				i2c9: i2c-bus@0x380 {
+					reg = <0x380 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <9>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+				i2c10: i2c-bus@0x3C0 {
+					reg = <0x380 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <10>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+				i2c11: i2c-bus@0x400 {
+					reg = <0x400 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <11>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+				i2c12: i2c-bus@0x440 {
+					reg = <0x400 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <12>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+				i2c13: i2c-bus@0x480 {
+					reg = <0x480 0x40>;
+					compatible = "aspeed,ast2400-i2c-bus";
+					bus = <13>;
+					clock-frequency = <100000>;
+					status = "disabled";
+				};
+
+			};
+
+			syscon: syscon@1e6e2000 {
+				compatible = "aspeed,syscon", "syscon";
+				reg = <0x1e6e2000 0x1a8>;
+				interrupts = <19>;
+				clocks = <&clk_apb>;
+				status = "okay";
+			};
+
+			wdt: wdt@1e785000 {
+				compatible = "aspeed,wdt", "wdt";
+				reg = <0x1e785000 0x1c4>;
+				interrupts = <27>;
+				clocks = <&clk_apb>;
+			};
+
+			rtc: rtc@1e781000 {
+				compatible = "aspeed,rtc";
+				reg = <0x1e781000 0x18>;
+			};
+
+			timer: timer@98400000 {
+				compatible = "aspeed,timer";
+				reg = <0x1e782000 0x90>;
+				// The moxart_timer driver registers only one interrupt
+				// and assumes it's for timer 1
+				//interrupts = <16 17 18 35 36 37 38 39>;
+				interrupts = <16>;
+				clocks = <&clk_apb>;
+			};
+
+			gpio: gpio@1e780000 {
+			       compatible = "aspeed,ast2400-gpio";
+			       reg = <0x1e780000 0x1000>;
+			       interrupts = <20>;
+			};
+
+			uart1: serial@1e783000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e783000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <9>;
+			       clock-frequency = < 1843200 >;
+			       no-loopback-test;
+			};
+			uart2: serial@1e78d000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e78d000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <32>;
+			       clock-frequency = < 1843200 >;
+			       no-loopback-test;
+			};
+			/* APSS UART */
+			uart3: serial@1e78e000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e78e000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <33>;
+			       clock-frequency = < 1843200 >;
+			       no-loopback-test;
+			};
+
+			/* Host UART */
+			uart4: serial@1e78f000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e78f000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <34>;
+			       clock-frequency = < 1843200 >;
+			       current-speed = < 115200 >;
+			       no-loopback-test;
+			};
+#if 1
+			/* BMC UART */
+			uart5: serial@1e784000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e784000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <10>;
+			       clock-frequency = < 1843200 >;
+			       current-speed = < 38400 >;
+			       no-loopback-test;
+			};
+#endif
+
+			uart6: serial@1e787000 {
+			       compatible = "ns16550a";
+			       reg = <0x1e787000 0x1000>;
+			       reg-shift = <2>;
+			       interrupts = <10>;
+			       clock-frequency = < 1843200 >;
+			       current-speed = < 38400 >;
+			       no-loopback-test;
+			};
+		};
+	};
+};

--- a/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/recipes-kernel/linux/linux-obmc_%.bbappend
+++ b/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/recipes-kernel/linux/linux-obmc_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/linux-obmc:"
+SRC_URI += "file://barreleye.dts"

--- a/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/recipes.txt
+++ b/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/recipes.txt
@@ -1,2 +1,3 @@
 recipes-bsp          - Anything with links to specific hardware or hardware configuration information
+recipes-kernel       - The kernel and generic applications/libraries with strong kernel dependencies
 recipes-phosphor     - Phosphor OpenBMC applications and configuration

--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.2.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.2.bb
@@ -18,3 +18,13 @@ COMPATIBLE_MACHINE_${MACHINE} = "openbmc"
 
 inherit kernel
 require recipes-kernel/linux/linux-yocto.inc
+
+do_patch_append() {
+        for DTB in "${KERNEL_DEVICETREE}"; do
+		DT=`basename ${DTB} .dtb`
+                if [ -r "${WORKDIR}/${DT}.dts" ]; then
+                        cp ${WORKDIR}/${DT}.dts \
+                                ${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts
+		fi
+	done
+}


### PR DESCRIPTION
This patchset moves from using the in kernel tree device tree to an out of tree one for both Palmetto and Barreleye.