### PR TITLE
Enable robottest for ssh

### DIFF
--- a/yocto-poky/meta/recipes-core/dropbear/dropbear.inc
+++ b/yocto-poky/meta/recipes-core/dropbear/dropbear.inc
@@ -17,6 +17,7 @@ SRC_URI = "http://matt.ucc.asn.au/dropbear/releases/dropbear-${PV}.tar.bz2 \
            file://0003-configure.patch \
            file://0004-fix-2kb-keys.patch \
            file://0007-dropbear-fix-for-x32-abi.patch \
+           file://0010-stop-robot-test-SSHLibrary-from-hanging.patch \
            file://init \
            file://dropbearkey.service \
            file://dropbear@.service \

--- a/yocto-poky/meta/recipes-core/dropbear/dropbear/0010-stop-robot-test-SSHLibrary-from-hanging.patch
+++ b/yocto-poky/meta/recipes-core/dropbear/dropbear/0010-stop-robot-test-SSHLibrary-from-hanging.patch
@@ -1,0 +1,28 @@
+From aa4ff477eed539085609dc9a8a011ff2f010bd1c Mon Sep 17 00:00:00 2001
+From: Chris Austen <austenc@us.ibm.com>
+Date: Fri, 6 Nov 2015 13:15:54 -0600
+Subject: [PATCH] stop robot test SSHLibrary from hanging
+
+This reverts a change made in this commit
+
+https://github.com/mkj/dropbear/commit/ca86726f9f943b2b18e5694b442d3d2e1c0fa903
+---
+ common-channel.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/common-channel.c b/common-channel.c
+index abe5941..5a02d73 100644
+--- a/common-channel.c
++++ b/common-channel.c
+@@ -258,6 +258,8 @@ void channelio(fd_set *readfds, fd_set *writefds) {
+ 			do_check_close = 1;
+ 			ses.channel_signal_pending = 0;
+ 		}
++
++do_check_close = 1;
+ 	
+ 		/* handle any channel closing etc */
+ 		if (do_check_close) {
+-- 
+1.9.1
+


### PR DESCRIPTION
Dropbear last year added a change that breaks the SSHLibrary for
robot test framework.

Details about the problem...
https://github.com/robotframework/SSHLibrary/issues/128

The actual commit that caused the problem
https://github.com/mkj/dropbear/commit/ca86726f9f943b2b18e5694b442d3d2e1c0fa903