### PR TITLE
add: build status on main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# OpenBMC #
+
+[![Build Status](https://openpower.xyz/buildStatus/icon?job=openbmc-build)](https://openpower.xyz/job/openbmc-build/)
+
 ## Building ##
 
 OpenBMC uses Yocto/Open-Embedded for a build system, which supports an 


### PR DESCRIPTION
This commit adds an image to the main openbmc GitHub page which shows the current build status, with a link to the Jenkins job.