### PR TITLE
python-dbus dbus.Byte.__str__ produces broken utf8

### DIFF
--- a/meta-phosphor/common/recipes-devtools/python/python-dbus/bytes.patch
+++ b/meta-phosphor/common/recipes-devtools/python/python-dbus/bytes.patch
@@ -1,0 +1,37 @@
+Index: dbus-python-1.2.0/_dbus_bindings/bytes.c
+===================================================================
+--- dbus-python-1.2.0.orig/_dbus_bindings/bytes.c
++++ dbus-python-1.2.0/_dbus_bindings/bytes.c
+@@ -138,23 +138,6 @@ bad_range:
+     return NULL;
+ }
+ 
+-static PyObject *
+-Byte_tp_str(PyObject *self)
+-{
+-    long i = NATIVEINT_ASLONG(self);
+-    unsigned char str[2] = { 0, 0 };
+-
+-    if (i == -1 && PyErr_Occurred())
+-        return NULL;
+-    if (i < 0 || i > 255) {
+-        PyErr_SetString(PyExc_RuntimeError, "Integer outside range 0-255");
+-        return NULL;
+-    }
+-
+-    str[0] = (unsigned char)i;
+-    return PyUnicode_FromStringAndSize((char *)str, 1);
+-}
+-
+ PyTypeObject DBusPyByte_Type = {
+         PyVarObject_HEAD_INIT(DEFERRED_ADDRESS(&PyType_Type), 0)
+         "dbus.Byte",
+@@ -171,7 +154,7 @@ PyTypeObject DBusPyByte_Type = {
+         0,                                      /* tp_as_mapping */
+         0,                                      /* tp_hash */
+         0,                                      /* tp_call */
+-        Byte_tp_str,                            /* tp_str */
++        0,                                      /* tp_str */
+         0,                                      /* tp_getattro */
+         0,                                      /* tp_setattro */
+         0,                                      /* tp_as_buffer */

--- a/meta-phosphor/common/recipes-devtools/python/python-dbus_1.2.0.bbappend
+++ b/meta-phosphor/common/recipes-devtools/python/python-dbus_1.2.0.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://bytes.patch"


### PR DESCRIPTION
Byte to string simply copied the byte, which isn't valid
utf8 for non ascii values.  Since dbus.byte is an int subclass,
should just be using int's __str__  implementation anyway.