### PR TITLE
meta-phosphor: Update kernel version

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.2.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.2.bb
@@ -2,15 +2,15 @@ DESCRIPTION = "Linux kernel for OpenBMC"
 SECTION = "kernel"
 LICENSE = "GPLv2"
 
-KBRANCH ?= "dev"
+KBRANCH ?= "dev-4.3"
 KCONFIG_MODE="--alldefconfig"
 
 SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 
-LINUX_VERSION ?= "4.2"
+LINUX_VERSION ?= "4.3"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20151104-1"
+SRCREV="openbmc-20151123-1"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
@@ -18,13 +18,3 @@ COMPATIBLE_MACHINE_${MACHINE} = "openbmc"
 
 inherit kernel
 require recipes-kernel/linux/linux-yocto.inc
-
-do_patch_append() {
-        for DTB in "${KERNEL_DEVICETREE}"; do
-		DT=`basename ${DTB} .dtb`
-                if [ -r "${WORKDIR}/${DT}.dts" ]; then
-                        cp ${WORKDIR}/${DT}.dts \
-                                ${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts
-		fi
-	done
-}


### PR DESCRIPTION
The kernel contains many changes, including

  - rewritten i2c driver
  - interrupt facilities for the iBT host driver
  - drop dts patches, we now use the in-tree device tree
  - rebased on Linux 4.3

Signed-off-by: Joel Stanley <joel@jms.id.au>