### PR TITLE
Set dropbearkey service to start on boot

### DIFF
--- a/meta-phosphor/common/recipes-core/dropbear/dropbear/dropbearkey.service
+++ b/meta-phosphor/common/recipes-core/dropbear/dropbear/dropbearkey.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=SSH Key Generation
+ConditionPathExists=|!/etc/dropbear/dropbear_rsa_host_key
+
+[Service]
+Type=oneshot
+ExecStart=@SBINDIR@/dropbearkey -t rsa -f /etc/dropbear/dropbear_rsa_host_key
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-phosphor/common/recipes-core/dropbear/dropbear_%.bbappend
+++ b/meta-phosphor/common/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+SRC_URI += "file://dropbearkey.service"


### PR DESCRIPTION
Before this patch it isn't started until the first
client connection which is not the desired behavior.