### PR TITLE
meta-phosphor: Update kernel to openbmc-20151210-1

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 LINUX_VERSION ?= "4.3"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20151202-1"
+SRCREV="openbmc-20151210-1"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
 - Temporary AST setup for Palmetto and Barreleye
 - Ensure all IP will be reset on reboot

These changes should help us to be less acceptable to userspace messing
up the configuration and causing bugs like the failure to reboot.

Signed-off-by: Joel Stanley <joel@jms.id.au>