### PR TITLE
os-release VERSION always points at v0.1

### DIFF
--- a/meta-phosphor/common/recipes-core/os-release/os-release.bbappend
+++ b/meta-phosphor/common/recipes-core/os-release/os-release.bbappend
@@ -6,7 +6,7 @@ def run_git(d, cmd):
                 pass
 
 python() {
-        version_id = run_git(d, 'tag')
+        version_id = run_git(d, 'describe --abbrev=0')
         if version_id:
                 d.setVar('VERSION_ID', version_id)
 
@@ -16,3 +16,4 @@ python() {
 }
 
 OS_RELEASE_FIELDS_append = " BUILD_ID"
+do_compile[nostamp] = "1"


### PR DESCRIPTION
Use git-describe rather than git-tag.
Make os-release do_compile run every time.