### PR TITLE
Resolve relocation warnings with build

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
@@ -14,7 +14,7 @@ DEPENDS += "systemd    \
 
 RDEPENDS_${PN} += "libsystemd"
 
-TARGET_CFLAGS += "-std=gnu++14"
+TARGET_CFLAGS += " -fpic -std=gnu++14"
 
 SRC_URI += "git://github.com/openbmc/ipmi-fru-parser"
 

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-oem.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-oem.bb
@@ -10,6 +10,7 @@ inherit obmc-phosphor-license
 DEPENDS += "systemd    \
 		 	host-ipmid \
 		 	"
+TARGET_CFLAGS += "-fpic"
 
 
 RDEPENDS_${PN} += "libsystemd"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -12,6 +12,9 @@ inherit obmc-phosphor-license
 inherit obmc-phosphor-sdbus-service
 inherit obmc-phosphor-c-daemon
 
+TARGET_CFLAGS   += "-fpic"
+
+
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
 SRCREV = "e90d8bf6a342649dba2fd1589a3cddb3cd051bb1"


### PR DESCRIPTION
Yocto's QA service identified issues with the build
The -fpic option was not included in .so files.
Resovles issue https://github.com/openbmc/openbmc/issues/105