### PR TITLE
qemu-native: fix build on Ubuntu 15.10

### DIFF
--- a/yocto-poky/meta/recipes-devtools/qemu/qemu.inc
+++ b/yocto-poky/meta/recipes-devtools/qemu/qemu.inc
@@ -43,6 +43,12 @@ do_configure_prepend_class-native() {
 	BHOST_PKGCONFIG_PATH=$(PATH=/usr/bin:/bin pkg-config --variable pc_path pkg-config || echo "")
 	if [ ! -z "$BHOST_PKGCONFIG_PATH" ]; then
 		export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$BHOST_PKGCONFIG_PATH
+		# link with system dbus on Ubuntu 15.10
+		# FIXME: remove below 4 lines when oe dbus is upgraded
+		if [ -r /etc/lsb-release -a "$(lsb_release -is)$(lsb_release -rs)" = "Ubuntu15.10" ] ; then
+			libs=$(PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_PATH=$BHOST_PKGCONFIG_PATH PATH=/usr/bin:/bin pkg-config --libs dbus-1 || echo "")
+			[ -n "$libs" ] && export LDFLAGS="$libs $LDFLAGS"
+		fi
 	fi
 }
 


### PR DESCRIPTION
Build of qemu-native on Ubuntu 15.10 fails on configure step.
The reason for this is that system dbus version is higher than
oe dbus version and system pulseaudio libraries require newer dbus.

It causes configure to break with a lot of errors similar to this:
  libpulsecommon-6.0.so: undefined reference to dbus_watch_get_enabled@LIBDBUS_1_3

Fixed by building qemu-native with the system dbus on Ubuntu 15.10

Note: This is a workaround. It must be removed when oe dbus is upgraded
to the version >= system dbus version (1.10.0 at the moment).

[YOCTO #8553]

Signed-off-by: Andrew Jeffery <andrew@aj.id.au>
Signed-off-by: Ed Bartosh <ed.bartosh@linux.intel.com>