### PR TITLE
Add workaround to avoid disabling serial console

### DIFF
--- a/meta-phosphor/common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-phosphor/common/recipes-core/systemd/systemd_%.bbappend
@@ -6,4 +6,8 @@ FILES_${PN} += "${libdir}/systemd/network/default.network"
 
 do_install_append() {
         install -m 644 ${WORKDIR}/default.network ${D}${libdir}/systemd/network/
+
+        #TODO Remove after this issue is resolved
+        #https://github.com/openbmc/openbmc/issues/152
+        ln -s /dev/null ${D}/etc/systemd/system/systemd-hwdb-update.service
 }


### PR DESCRIPTION
This is a workaround for issue:
https://github.com/openbmc/openbmc/issues/152
Once the issue is resolved, this workaround can be removed.