### PR TITLE
Add network dbus object to openbmc image

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -15,6 +15,7 @@ inherit obmc-phosphor-c-daemon
 TARGET_CFLAGS   += "-fpic"
 
 RDEPENDS_${PN} += "settings"
+RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
 SRCREV = "e90d8bf6a342649dba2fd1589a3cddb3cd051bb1"

--- a/meta-phosphor/common/recipes-phosphor/network/network.bb
+++ b/meta-phosphor/common/recipes-phosphor/network/network.bb
@@ -1,0 +1,21 @@
+SUMMARY = "Network DBUS object"
+DESCRIPTION = "Network DBUS object"
+HOMEPAGE = "http://github.com/openbmc/phosphor-networkd"
+PR = "r1"
+
+inherit obmc-phosphor-license
+inherit obmc-phosphor-systemd
+
+RDEPENDS_${PN} += "python-dbus python-pygobject"
+
+SRC_URI += "git://github.com/openbmc/phosphor-networkd"
+
+SRCREV = "a657afc9cc76dc6678edb8de9df569f92dd108e1"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+        install -d ${D}/${sbindir}
+        install ${S}/netman.py ${D}/${sbindir}
+}
+

--- a/meta-phosphor/common/recipes-phosphor/network/network/network.service
+++ b/meta-phosphor/common/recipes-phosphor/network/network/network.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Network DBUS object
+Requires=skeleton.service
+After=skeleton.service
+
+[Service]
+ExecStart=/usr/sbin/netman.py
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Create networkd recipe and service files
Add dependency to networkd to the ipmid recipe
since the upcoming ipmi set/get lan ipmi cmds will
make use of the network dbus object