### PR TITLE
meta-phosphor: Update kernel version

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 LINUX_VERSION ?= "4.3"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20160202-1"
+SRCREV="openbmc-20160202-2"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 

--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 LINUX_VERSION ?= "4.3"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20160127-1"
+SRCREV="openbmc-20160202-1"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
Move to openbmc-20160202-2. Between -1 and -2, we get the following:

 - Stable release 4.3.5
   - Only impact for us are some fixes for the core networking layer
 - First pass of VUART patches from Jeremy
 - Build fix for the OCC hwmon driver
 - Locking fixes for ncsi and i2c

Signed-off-by: Joel Stanley <joel@jms.id.au>