### PR TITLE
Update phosphor recipes to pickup latest code

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
@@ -18,7 +18,7 @@ TARGET_CFLAGS += " -fpic -std=gnu++14"
 
 SRC_URI += "git://github.com/openbmc/ipmi-fru-parser"
 
-SRCREV = "63696f4b23c9fd0a84ce539a6414ada406aaf229"
+SRCREV = "a14239a201443222906864273449a39cfa84118e"
 
 FILES_${PN} += "${libdir}/host-ipmid/*.so"
 FILES_${PN}-dbg += "${libdir}/host-ipmid/.debug"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = "e90d8bf6a342649dba2fd1589a3cddb3cd051bb1"
+SRCREV = ""
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "ipmid"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = ""
+SRCREV = "83edabb0e05fd71d4905ef255e97f65d966c6e7e"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "ipmid"

--- a/meta-phosphor/common/recipes-phosphor/network/network.bb
+++ b/meta-phosphor/common/recipes-phosphor/network/network.bb
@@ -12,7 +12,7 @@ SRC_URI += "git://github.com/openbmc/phosphor-networkd \
             file://80-dhcp.network \
             "
 
-SRCREV = "a657afc9cc76dc6678edb8de9df569f92dd108e1"
+SRCREV = "6b3d6af5b9c38d734f20e859394db275e141328e"
 
 S = "${WORKDIR}/git"
 

--- a/meta-phosphor/common/recipes-phosphor/settings/settings.bb
+++ b/meta-phosphor/common/recipes-phosphor/settings/settings.bb
@@ -10,7 +10,7 @@ RDEPENDS_${PN} += "python-dbus python-pygobject"
 
 SRC_URI += "git://github.com/openbmc/phosphor-settingsd"
 
-SRCREV = "33e0930724c12f83ddf99f7452fc0551ac10ccfc"
+SRCREV = "3bda531d94f4c93473bbedd7d7e5c44d4d9da93b"
 
 S = "${WORKDIR}/git"
 

--- a/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
@@ -13,10 +13,10 @@ inherit obmc-phosphor-sensor-mgmt
 inherit obmc-phosphor-system-mgmt
 
 DEPENDS += "glib-2.0"
-RDEPENDS_${PN} += "python-subprocess python-tftpy"
+RDEPENDS_${PN} += "python-subprocess python-compression"
 SRC_URI += "git://github.com/openbmc/skeleton"
 
-SRCREV = "abe4953f941f63b4a3f531af15f6dba68870f3a9"
+SRCREV = "695f5d12e33daece376ddf1f9c7041a5bd6a3c7d"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
Update openbmc phosphor recipes to pickup latest functionality from
skeleton, ipmi, networkd, settings, etc.