### PR TITLE
Update recipes and remove dhcp file

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 LINUX_VERSION ?= "4.3"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20160202-2"
+SRCREV="fe68a785afbaa305506c87c6324f70ed0605385c"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = "83edabb0e05fd71d4905ef255e97f65d966c6e7e"
+SRCREV = "bec22bb7cf730147bf4b036fa9237b8495be4e75"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "ipmid"

--- a/meta-phosphor/common/recipes-phosphor/network/network.bb
+++ b/meta-phosphor/common/recipes-phosphor/network/network.bb
@@ -8,18 +8,14 @@ inherit obmc-phosphor-systemd
 
 RDEPENDS_${PN} += "python-dbus python-pygobject"
 
-SRC_URI += "git://github.com/openbmc/phosphor-networkd \
-            file://80-dhcp.network \
-            "
+SRC_URI += "git://github.com/openbmc/phosphor-networkd"
 
-SRCREV = "6b3d6af5b9c38d734f20e859394db275e141328e"
+SRCREV = "1e1fe01bb7c1b3cebbe484f83b1729be331d3c37"
 
 S = "${WORKDIR}/git"
 
 do_install() {
         install -d ${D}/${sbindir}
         install ${S}/netman.py ${D}/${sbindir}
-        install -d ${D}/etc/systemd/network/
-        install ${WORKDIR}/80-dhcp.network ${D}/etc/systemd/network/
 }
 

--- a/meta-phosphor/common/recipes-phosphor/network/network/80-dhcp.network
+++ b/meta-phosphor/common/recipes-phosphor/network/network/80-dhcp.network
@@ -1,5 +1,0 @@
-[Match]
-Name=eth0
-
-[Network]
-DHCP=yes


### PR DESCRIPTION
Backout kernel level since tag 20160202 has vuart support that bmc
currently does not support
Pickup IPMI and REST functions to update the MAC address
Remove dhcp file from network recipe that seems to cause issues
Update skeleton with syntax fix