### PR TITLE
initfs: check and auto-repair read/write file system

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -75,12 +75,36 @@ roopts=ro
 rwopts=rw
 
 init=/sbin/init
+fsck=/sbin/fsck.$rwfst
+fsckopts=-a
 
 echo rofs = $rofs $rofst   rwfs = $rwfs $rwfst
 
 if grep -w debug-init-sh /proc/cmdline
 then
 	debug_takeover "Debug initial shell requested by command line."
+fi
+
+mount $rodev $rodir -t $rofst -o $roopts
+
+if test -x $rodir$fsck
+then
+	for fs in $fslist
+	do
+		mount --bind $fs $rodir/$fs
+	done
+	chroot $rodir $fsck $fsckopts $rwdev
+	rc=$?
+	for fs in $fslist
+	do
+		umount $rodir/$fs
+	done
+	if test $rc -gt 1
+	then
+		debug_takeover "fsck of read-write fs on $rwdev failed (rc=$rc)"
+	fi
+else
+	echo "No '$fsck' in read only fs, skipping fsck."
 fi
 
 if ! mount $rwdev $rwdir -t $rwfst -o $rwopts
@@ -93,11 +117,8 @@ HERE
 	debug_takeover "$msg"
 fi
 
-mount $rodev $rodir -t $rofst -o $roopts
-
 rm -rf $work
-mkdir -p $upper
-mkdir -p $work
+mkdir -p $upper $work
 
 mount -t overlay -o lowerdir=$rodir,upperdir=$upper,workdir=$work cow /root
 

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -1,12 +1,13 @@
 #!/bin/sh
 
+fslist="proc sys dev run"
 rodir=run/initramfs/ro
 rwdir=run/initramfs/rw
 upper=$rwdir/cow
 work=$rwdir/work
 
 cd /
-mkdir -p sys proc dev run
+mkdir -p $fslist
 mount dev dev -tdevtmpfs
 mount sys sys -tsysfs
 mount proc proc -tproc
@@ -39,13 +40,20 @@ fi
 rofs=$(findmtd rofs)
 rwfs=$(findmtd rwfs)
 
+rodev=/dev/mtdblock${rofs#mtd}
+rwdev=/dev/mtdblock${rwfs#mtd}
+
 rofst=squashfs
 rwfst=ext4
+roopts=ro
+rwopts=rw
+
+init=/sbin/init
 
 echo rofs = $rofs $rofst   rwfs = $rwfs $rwfst
 
 if grep -w debug-init-sh /proc/cmdline ||
-	! mount -o rw /dev/mtdblock${rwfs#mtd} $rwdir -t $rwfst
+	! mount $rwdev $rwdir -t $rwfst -o $rwopts
 then
 	echo Please mount the rw file system on $rwdir from this shell
 	while ! sulogin && ! test -f /takeover
@@ -61,7 +69,7 @@ then
 	exec /bin/sh
 fi
 
-mount -o ro /dev/mtdblock${rofs#mtd} $rodir -t $rofst
+mount $rodev $rodir -t $rofst -o $roopts
 
 rm -rf $work
 mkdir -p $upper
@@ -69,17 +77,17 @@ mkdir -p $work
 
 mount -t overlay -o lowerdir=$rodir,upperdir=$upper,workdir=$work cow /root
 
-if ! chroot /root /bin/sh -c "test -x /sbin/init -a -s /sbin/init"
+if ! chroot /root /bin/sh -c "test -x '$init' -a -s '$init'"
 then
 	echo "Change Root test failed!  Invoking emergency shell."
 	PS1=rescue#\  sulogin
 fi
 
-for f in sys dev proc run
+for f in $fslist
 do
 	mount --move $f root/$f
 done
 
-# switch_root /root /sbin/init
-exec chroot /root /sbin/init
+# switch_root /root $init
+exec chroot /root $init
 

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -69,9 +69,9 @@ mkdir -p $work
 
 mount -t overlay -o lowerdir=$rodir,upperdir=$upper,workdir=$work cow /root
 
-if ! chroot /root /bin/sh -c exit
+if ! chroot /root /bin/sh -c "test -x /sbin/init -a -s /sbin/init"
 then
-	echo 'chroot test failed; invoking emergency shell.'
+	echo "Change Root test failed!  Invoking emergency shell."
 	PS1=rescue#\  sulogin
 fi
 

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -34,14 +34,13 @@ fi
 
 if test -x /update && ls $image* > /dev/null 2>&1
 then
-	exec /update ${1+"$@"}
+	/update ${1+"$@"}
 fi
 
 echo Remaining mounts:
 cat /proc/mounts
 
 test "umount_proc" && umount /proc && rmdir /proc
-
 
 
 # Execute the command systemd told us to ...

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -15,11 +15,16 @@ else
 	umount_proc=
 fi
 
-# remove an empty oldroot, that means we are not invoked from systemd-shutdown
+# Remove an empty oldroot, that means we are not invoked from systemd-shutdown
 rmdir /oldroot 2>/dev/null
 
+# Move /oldroot/run to /mnt in case it has the underlying rofs loop mounted.
+# Ordered before /oldroot the overlay is unmounted before the loop mount
+mkdir -p /mnt
+mount --move /oldroot/run /mnt
+
 set -x
-for f in $( awk '/oldroot/ { print $2 }' < /proc/mounts | sort -r )
+for f in $( awk '/oldroot|mnt/ { print $2 }' < /proc/mounts | sort -r )
 do
 	umount $f
 done

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -5,10 +5,11 @@ echo shutdown: "$@"
 export PS1=shutdown-sh#\ 
 # exec bin/sh
 
+cd /
 if [ ! -e /proc/mounts ]
 then
 	mkdir -p /proc
-	mount  proc proc -tproc
+	mount  proc /proc -tproc
 	umount_proc=1
 else
 	umount_proc=
@@ -27,10 +28,10 @@ set +x
 if test -s /run/fw_env -a -c /run/mtd:u-boot-env -a ! -e /image-u-boot-env &&
 	! cmp /run/mtd:u-boot-env /run/fw_env
 then
-	ln -s /run/fw_env /image-u-boot-env
+	ln -sn /run/fw_env /image-u-boot-env
 fi
 
-if test -x /update && ls image-* > /dev/null 2>&1
+if test -x /update && ls /image-* > /dev/null 2>&1
 then
 	exec /update ${1+"$@"}
 fi

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -25,13 +25,14 @@ do
 done
 set +x
 
-if test -s /run/fw_env -a -c /run/mtd:u-boot-env -a ! -e /image-u-boot-env &&
+image=/run/initramfs/image-
+if test -s /run/fw_env -a -c /run/mtd:u-boot-env -a ! -e ${image}u-boot-env &&
 	! cmp /run/mtd:u-boot-env /run/fw_env
 then
-	ln -sn /run/fw_env /image-u-boot-env
+	ln -sn /run/fw_env ${image}u-boot-env
 fi
 
-if test -x /update && ls /image-* > /dev/null 2>&1
+if test -x /update && ls $image* > /dev/null 2>&1
 then
 	exec /update ${1+"$@"}
 fi

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -92,19 +92,12 @@ then
 	umount $rwdir
 fi
 
-# Execute the command systemd told us to ...
-if test -d /oldroot && test -x "/sbin/$1" && test -f "/sbin/$1"
-then
-	if test "$1" == kexec
-	then
-		/sbin/$1 -f -e
-	else
-		/sbin/$1 -f
-	fi
-fi
+exit
 
+# NOT REACHED without edit
+# NOT REACHED without edit
 
-echo "Execute ${1-reboot} -f if all is ok"
+echo "Flash completed.  Inspect, cleanup and reboot -f to continue."
 
 export PS1=update-sh#\ 
 exec /bin/sh

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -61,10 +61,10 @@ then
 	umount rw
 fi
 
-
-for f in image-*
+image=/run/initramfs/image-
+for f in $image*
 do
-	m=$(findmtd ${f#image-})
+	m=$(findmtd ${f#$image})
 	if test -z "$m"
 	then
 		echo 1>&2  "Unable to find mtd partiton for $f"
@@ -72,10 +72,10 @@ do
 	fi
 done
 
-for f in image-*
+for f in $image*
 do
-	m=$(findmtd ${f#image-})
-	echo "Updating ${f#image-}"
+	m=$(findmtd ${f#$image})
+	echo "Updating ${f#$image}..."
 	# flasheraseall /dev/$m && dd if=$f of=/dev/$m
 	flashcp -v $f /dev/$m
 done

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -35,30 +35,35 @@ findmtd() {
 	echo $m
 }
 
-rofs=$(findmtd rofs)
 rwfs=$(findmtd rwfs)
 
-rofst=squahsfs
+rwdev=/dev/mtdblock${rwfs#mtd}
 rwfst=ext4
+rwopts=rw
+rorwopts=ro${rwopts#rw}
+
+rwdir=rw
+upper=$rwdir/cow
+save=save/${upper##*/}
 
 if test -n "$rwfs" && test -s whitelist
 then
 
-	mkdir -p rw
-	mount /dev/mtdblock${rwfs#mtd} rw -oro -t $rwfst
+	mkdir -p $rwdir
+	mount $rwdev $rwdir -t $rwfst -o $rorwopts
 
 	while read f
 	do
-		if ! test -e rw/cow/$f
+		if ! test -e $upper/$f
 		then
 			continue
 		fi
-		d="save/cow/$f"
+		d="$save/$f"
 		mkdir -p "${d%/*}"
-		cp -rp rw/cow/$f "${d%/*}/"
+		cp -rp $upper/$f "${d%/*}/"
 	done < whitelist
 
-	umount rw
+	umount $rwdir
 fi
 
 image=/run/initramfs/image-
@@ -67,7 +72,7 @@ do
 	m=$(findmtd ${f#$image})
 	if test -z "$m"
 	then
-		echo 1>&2  "Unable to find mtd partiton for $f"
+		echo 1>&2  "Unable to find mtd partiton for ${f##*/}."
 		exec /bin/sh
 	fi
 done
@@ -80,12 +85,11 @@ do
 	flashcp -v $f /dev/$m
 done
 
-
-if test -d save/cow
+if test -d $save
 then
-	mount /dev/mtdblock${rwfs#mtd} rw -o rw -t $rwfst
-	cp -rp save/cow/. rw/cow/
-	umount rw
+	mount $rwdev rw -t $rwfst -o rw
+	cp -rp $save/. $upper/
+	umount $rwdir
 fi
 
 # Execute the command systemd told us to ...


### PR DESCRIPTION
This series of patches to the obmc init, shutdown, and update scripts adds several features, including

Run fsck on the read write filesystem before mounting.
More information on what to do and options when init fails
Consistent location of update images even during init repair cases

Plus these developer features
All mount arguments consolidated into variables
Clean unmount when testing rofs image in RAM (from the /run file system)
Other clean ups

This second version has 1 update over the first version #165.  The prior version had
mistakenly used rodir for both device and directory options to mount in "use variables" patch.  I had caught and corrected when moving the line up in the "run fsck" patch but missed the same error occurred in the prior location.

i've now done a boot and shutdown test on each of the patches and an update of u-boot-env on most of them.  In addition I've used the penultimate and final version several times including the debug-init-sh option and the failed to fsck path and done end-to-end image-rwfs update with preserved files.
