### PR TITLE
Prep work for presistent event logs

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
@@ -9,6 +9,7 @@ inherit obmc-phosphor-event-mgmt
 inherit obmc-phosphor-sdbus-service
 inherit obmc-phosphor-c-daemon
 
+TARGET_CPPFLAGS += "-std=c++11 -fpic"
 
 SRC_URI += "git://github.com/openbmc/phosphor-event"
 
@@ -22,6 +23,7 @@ S = "${WORKDIR}/git"
 INSTALL_NAME = "event_messaged"
 
 do_install() {
+        install -d ${D}/var/lib/obmc/events/
         install -m 0755 -d ${D}${sbindir}
         install -m 0755 ${S}/${INSTALL_NAME} ${D}/${sbindir}/obmc-phosphor-eventd
 }


### PR DESCRIPTION
Making a very simple commit that contains the additional required
c++ flags along with making the directory to store the new event
manager log files.  This does not enable anything, it is a
precursor got the big drop.  I'd like to get some of the more
simple things in to the build first since a 2 line change is
faster to review.