### PR TITLE
Initfs fsck v3

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -30,6 +30,34 @@ findmtd() {
 	echo $m
 }
 
+debug_takeover() {
+	echo "$@"
+	test -n "$@" && echo Enter password to try to manually fix.
+	cat << HERE
+After fixing run exit to continue this script, or reboot -f to retry, or
+touch /takeover and exit to become PID 1 allowing editing of this script.
+HERE
+
+	while ! sulogin && ! test -f /takeover
+	do
+		echo getty failed, retrying
+	done
+
+	# Touch /takeover in the above getty to become pid 1
+	if test -e /takeover
+	then
+		cat << HERE
+
+Takeover of init requested.  Executing /bin/sh as PID 1.
+When finished exec new init or cleanup and run reboot -f.
+
+Warning: No job control!  Shell exit will panic the system!
+HERE
+		export PS1=init#\ 
+		exec /bin/sh
+	fi
+}
+
 env=$(findmtd u-boot-env)
 if test -n $env
 then
@@ -52,21 +80,20 @@ init=/sbin/init
 
 echo rofs = $rofs $rofst   rwfs = $rwfs $rwfst
 
-if grep -w debug-init-sh /proc/cmdline ||
-	! mount $rwdev $rwdir -t $rwfst -o $rwopts
+if grep -w debug-init-sh /proc/cmdline
 then
-	echo Please mount the rw file system on $rwdir from this shell
-	while ! sulogin && ! test -f /takeover
-	do
-		echo getty failed, retrying
-	done
+	debug_takeover "Debug initial shell requested by command line."
 fi
 
-# Touch /takeover in the above getty to become pid 1
-if test -e /takeover
+if ! mount $rwdev $rwdir -t $rwfst -o $rwopts
 then
-	export PS1=init#\ 
-	exec /bin/sh
+	msg="$(cat)" << HERE
+
+Mounting read-write $rwdev filesystem failed.  Please fix and run
+	mount $rwdev $rwdir -t $rwfs -o $rwopts
+to to continue, or do change nothing to run from RAM for this boot.
+HERE
+	debug_takeover "$msg"
 fi
 
 mount $rodev $rodir -t $rofst -o $roopts
@@ -77,12 +104,17 @@ mkdir -p $work
 
 mount -t overlay -o lowerdir=$rodir,upperdir=$upper,workdir=$work cow /root
 
-if ! chroot /root /bin/sh -c "test -x '$init' -a -s '$init'"
-then
-	echo "Unable to confirm /sbin/init is an executable non-empty file."
-	echo "Change Root test failed!  Invoking emergency shell."
-	PS1=rescue#\  sulogin
-fi
+while ! chroot /root /bin/sh -c "test -x '$init' -a -s '$init'"
+do
+	msg="$(cat)" << HERE
+
+Unable to confirm /sbin/init is an executable non-empty file
+in merged file system mounted at /root.
+
+Change Root test failed!  Invoking emergency shell.
+HERE
+	debug_takeover "$msg"
+done
 
 for f in $fslist
 do

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -69,9 +69,10 @@ mkdir -p $work
 
 mount -t overlay -o lowerdir=$rodir,upperdir=$upper,workdir=$work cow /root
 
-if ! chroot /root /bin/sh -c exit
+if ! chroot /root /bin/sh -c "test -x /sbin/init -a -s /sbin/init"
 then
-	echo 'chroot test failed; invoking emergency shell.'
+	echo "Unable to confirm /sbin/init is an executable non-empty file."
+	echo "Change Root test failed!  Invoking emergency shell."
 	PS1=rescue#\  sulogin
 fi
 

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -34,14 +34,13 @@ fi
 
 if test -x /update && ls $image* > /dev/null 2>&1
 then
-	exec /update ${1+"$@"}
+	/update ${1+"$@"}
 fi
 
 echo Remaining mounts:
 cat /proc/mounts
 
 test "umount_proc" && umount /proc && rmdir /proc
-
 
 
 # Execute the command systemd told us to ...

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -15,11 +15,16 @@ else
 	umount_proc=
 fi
 
-# remove an empty oldroot, that means we are not invoked from systemd-shutdown
+# Remove an empty oldroot, that means we are not invoked from systemd-shutdown
 rmdir /oldroot 2>/dev/null
 
+# Move /oldroot/run to /mnt in case it has the underlying rofs loop mounted.
+# Ordered before /oldroot the overlay is unmounted before the loop mount
+mkdir -p /mnt
+mount --move /oldroot/run /mnt
+
 set -x
-for f in $( awk '/oldroot/ { print $2 }' < /proc/mounts | sort -r )
+for f in $( awk '/oldroot|mnt/ { print $2 }' < /proc/mounts | sort -r )
 do
 	umount $f
 done

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -27,7 +27,7 @@ set +x
 if test -s /run/fw_env -a -c /run/mtd:u-boot-env -a ! -e /image-u-boot-env &&
 	! cmp /run/mtd:u-boot-env /run/fw_env
 then
-	ln -s /run/fw_env /image-u-boot-env
+	ln -sn /run/fw_env /image-u-boot-env
 fi
 
 if test -x /update && ls image-* > /dev/null 2>&1

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -25,13 +25,14 @@ do
 done
 set +x
 
-if test -s /run/fw_env -a -c /run/mtd:u-boot-env -a ! -e /image-u-boot-env &&
+image=/run/initramfs/image-
+if test -s /run/fw_env -a -c /run/mtd:u-boot-env -a ! -e ${image}u-boot-env &&
 	! cmp /run/mtd:u-boot-env /run/fw_env
 then
-	ln -sn /run/fw_env /image-u-boot-env
+	ln -sn /run/fw_env ${image}u-boot-env
 fi
 
-if test -x /update && ls /image-* > /dev/null 2>&1
+if test -x /update && ls $image* > /dev/null 2>&1
 then
 	exec /update ${1+"$@"}
 fi

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -5,10 +5,11 @@ echo shutdown: "$@"
 export PS1=shutdown-sh#\ 
 # exec bin/sh
 
+cd /
 if [ ! -e /proc/mounts ]
 then
 	mkdir -p /proc
-	mount  proc proc -tproc
+	mount  proc /proc -tproc
 	umount_proc=1
 else
 	umount_proc=
@@ -30,7 +31,7 @@ then
 	ln -sn /run/fw_env /image-u-boot-env
 fi
 
-if test -x /update && ls image-* > /dev/null 2>&1
+if test -x /update && ls /image-* > /dev/null 2>&1
 then
 	exec /update ${1+"$@"}
 fi

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -92,19 +92,12 @@ then
 	umount $rwdir
 fi
 
-# Execute the command systemd told us to ...
-if test -d /oldroot && test -x "/sbin/$1" && test -f "/sbin/$1"
-then
-	if test "$1" == kexec
-	then
-		/sbin/$1 -f -e
-	else
-		/sbin/$1 -f
-	fi
-fi
+exit
 
+# NOT REACHED without edit
+# NOT REACHED without edit
 
-echo "Execute ${1-reboot} -f if all is ok"
+echo "Flash completed.  Inspect, cleanup and reboot -f to continue."
 
 export PS1=update-sh#\ 
 exec /bin/sh

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -61,10 +61,10 @@ then
 	umount rw
 fi
 
-
-for f in image-*
+image=/run/initramfs/image-
+for f in $image*
 do
-	m=$(findmtd ${f#image-})
+	m=$(findmtd ${f#$image})
 	if test -z "$m"
 	then
 		echo 1>&2  "Unable to find mtd partiton for $f"
@@ -72,10 +72,10 @@ do
 	fi
 done
 
-for f in image-*
+for f in $image*
 do
-	m=$(findmtd ${f#image-})
-	echo "Updating ${f#image-}"
+	m=$(findmtd ${f#$image})
+	echo "Updating ${f#$image}..."
 	# flasheraseall /dev/$m && dd if=$f of=/dev/$m
 	flashcp -v $f /dev/$m
 done


### PR DESCRIPTION
This series of patches to the obmc init, shutdown, and update scripts adds several features, including

Run fsck on the read write filesystem before mounting.
More information on what to do and options when init fails
Consistent location of update images even during init repair cases

Plus these developer features
All mount arguments consolidated into variables
Clean unmount when testing rofs image in RAM (from the /run file system)
Other clean ups

This version splits the first commit into 3 changes, and updates the messages to have more whitespace and a more explicit statement of the chroot test along with commit message edits.
It corrects a missed variable conversion of rwdir in update and loops on the chroot test.