### PR TITLE
Enable Persistent event logs in OBMC

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper.bb
+++ b/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper.bb
@@ -18,6 +18,6 @@ RDEPENDS_${PN} += " \
         "
 SRC_URI += "git://github.com/openbmc/phosphor-objmgr"
 
-SRCREV = "3f7aa329568d8f191baeeefa4a63dbb19cf26338"
+SRCREV = "956dd44fe5c8377ec90cef393f65033d59e082b0"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
@@ -13,7 +13,7 @@ TARGET_CPPFLAGS += "-std=c++11 -fpic"
 
 SRC_URI += "git://github.com/openbmc/phosphor-event"
 
-SRCREV = "aa9ec3aa2cc59fc7e2437041d89b19f4a8f1d7f0"
+SRCREV = "01ac3503dc97fb99bee9c25c23fe73a5f4ea0475"
 
 RDEPENDS_${PN} += "libsystemd"
 DEPENDS += "systemd"

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/whitelist
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/whitelist
@@ -6,3 +6,4 @@
 /etc/group
 /etc/shadow
 /etc/gshadow
+/var/lib/obmc/events/


### PR DESCRIPTION
Enable the /var/lib/obmc/events in the whitelist
Move pointers up for event manager and object manager