### PR TITLE
meta-phosphor: Bump kernel to 20160212-1

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 LINUX_VERSION ?= "4.3"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20160210-1"
+SRCREV="openbmc-20160212-1"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
Fixes in serial/aspeed-vuart:
 - Perform enable/disable on driver bind/unbind
 - Only disable host tx discard when serial port is in use

Plus a small device tree fix from Milton.

Signed-off-by: Joel Stanley <joel@jms.id.au>