### PR TITLE
Split whitelist into files by package.

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -18,7 +18,7 @@ fi
 
 mkdir -p $rodir $rwdir
 
-cp -rp init shutdown update whitelist bin sbin usr lib etc var run/initramfs
+cp -rp init shutdown update whitelist.d bin sbin usr lib etc var run/initramfs
 
 # To start a interactive shell with job control at this point, run
 # getty 38400 ttyS4

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -100,7 +100,7 @@ toram=
 checksize=y
 checkmount=y
 
-whitelist=/run/initramfs/whitelist
+whitelist=/run/initramfs/whitelist.d/
 image=/run/initramfs/image-
 imglist=
 
@@ -191,7 +191,9 @@ then
 		done
 		mkdir -p "${d%/*}"
 		cp -rp "$upper/$f" "${d%/*}/"
-	done < $whitelist
+	done << HERE
+$(grep -v ^# $whitelist*)
+HERE
 
 	if test -n "$mounted"
 	then

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/obmc-phosphor-initfs.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/obmc-phosphor-initfs.bb
@@ -21,10 +21,11 @@ do_install() {
         install -m 0755 ${WORKDIR}/obmc-init.sh ${D}/init
         install -m 0755 ${WORKDIR}/obmc-shutdown.sh ${D}/shutdown
         install -m 0755 ${WORKDIR}/obmc-update.sh ${D}/update
-        install -m 0644 ${WORKDIR}/whitelist ${D}/whitelist
+        install -d ${D}/whitelist.d
+        install -m 0644 ${WORKDIR}/whitelist ${D}/whitelist.d/whitelist
         install -d ${D}/dev
         mknod -m 622 ${D}/dev/console c 5 1
 }
 
-FILES_${PN} += " /init /shutdown /update /whitelist /dev "
+FILES_${PN} += " /init /shutdown /update /whitelist.d/whitelist /dev "
 FILES_${PN} += " /init-options /init-download-url "


### PR DESCRIPTION
The whitelist, a list of files and directories to preserve when updating the file system image, is not maintainable as a single file.  Each package should specify which files it wants saved, and a combined list generated.

This  patch is the first step of moving the white list content to a directory in the image and updating the scripts to look at the directory.  With this patch additional recipes can be added to the initramfs recipe that add additional files to be preserved across a "revert to factory image", such as adding shell history files as mentioned in #293.

Some design is needed to assemble the whitelist content from the various recipes because the whitelist is in the initramfs but it affects the packages in the main rootfs image.  Splitting the whitelist into fragments in the various package recipes is deferred for that design.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/180)
<!-- Reviewable:end -->