### PR TITLE
meta-phosphor: Update Linux to openbmc-20160222-1

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.3.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 LINUX_VERSION ?= "4.3"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20160212-1"
+SRCREV="openbmc-20160222-1"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
 - 4.3.6 stable release
 - mtd: spi-nor: aspeed-smc: Use io string accessors to fifo
 - i2c: aspeed: Don't rename added devices
 - Remove GPIO and LPC from WDT reset list

Signed-off-by: Joel Stanley <joel@jms.id.au>