### PR TITLE
Integrating support for event log enhancements

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-oem.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-oem.bb
@@ -19,7 +19,7 @@ RDEPENDS_${PN} += "libsystemd"
 
 SRC_URI += "git://github.com/openbmc/openpower-host-ipmi-oem"
 
-SRCREV = "b7df30ea8ad991c2d811e77ed4dee1beaa766883"
+SRCREV = "caa755e97b49d332e6100c086f5921d92be31c25"
 
 FILES_${PN} += "${libdir}/host-ipmid/*.so"
 FILES_${PN}-dbg += "${libdir}/host-ipmid/.debug"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -18,7 +18,7 @@ RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = "5d8c424a5c125b3cc5dcf67238e174b9dcaf22e6"
+SRCREV = "4bc8baeadbcc3cda3c2106e163fe4249f4ce3ff2"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "ipmid"

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
@@ -13,7 +13,7 @@ TARGET_CPPFLAGS += "-std=c++11 -fpic"
 
 SRC_URI += "git://github.com/openbmc/phosphor-event"
 
-SRCREV = "01ac3503dc97fb99bee9c25c23fe73a5f4ea0475"
+SRCREV = "127c8cf513ba9ed6bcc460fbea29b36eb8d23bac"
 
 RDEPENDS_${PN} += "libsystemd"
 DEPENDS += "systemd"


### PR DESCRIPTION
You will now get all the debug data in the event logs.  This was different
then in the past as there was a fixed few bytes of meaningless information.

The feature also reduces the memory footprint of the event manager AND
removes eselxxx logs in /tmp