### PR TITLE
inarp: Add inverse ARP daemon

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/inarp/inarp.bb
+++ b/meta-phosphor/common/recipes-phosphor/inarp/inarp.bb
@@ -1,0 +1,17 @@
+SUMMARY = "Inverse ARP daemon"
+DESCRIPTION = "Daemon to respond to Inverse-ARP requests"
+HOMEPAGE = "http://github.com/openbmc/inarp"
+PR = "r1"
+
+inherit obmc-phosphor-license
+inherit obmc-phosphor-c-daemon
+
+TARGET_CFLAGS   += "-fpic -O2"
+
+RDEPENDS_${PN} += "network"
+SRC_URI += "git://github.com/openbmc/inarp"
+
+SRCREV = "19ed5170356495f5fc67189513c5739780ee6a81"
+
+S = "${WORKDIR}/git"
+INSTALL_NAME = "inarp"

--- a/meta-phosphor/common/recipes-phosphor/inarp/inarp/inarp.service
+++ b/meta-phosphor/common/recipes-phosphor/inarp/inarp/inarp.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Phosphor Inverse ARP daemon
+
+[Service]
+ExecStart=/usr/sbin/inarp
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This change adds 'inarp': A small daemon to listen for, and reply to
inverse ARP requests.

This should be started at system init time, so we add a .service file.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>