### PR TITLE
Add inarp to base image

### DIFF
--- a/meta-phosphor/classes/obmc-phosphor-image.bbclass
+++ b/meta-phosphor/classes/obmc-phosphor-image.bbclass
@@ -41,6 +41,7 @@ IMAGE_INSTALL += " \
         packagegroup-obmc-phosphor-apps-extras \
         i2c-tools \
         screen \
+        inarp \
         "
 
 def build_overlay(d):


### PR DESCRIPTION
Add the inarp package to the base image. If users later want
to turn it off and not have it be part of the base image,
it can be changed to a distro spec then.