### PR TITLE
Update openbmc initfs to add temporary run from RAM 

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/clear-once/clear-once.bb
+++ b/meta-phosphor/common/recipes-phosphor/clear-once/clear-once.bb
@@ -1,0 +1,8 @@
+
+SUMMARY = "Clear boot-once variables"
+DESCRIPTION = "Clear u-boot variables used for one-time boot flow"
+
+RPROVIDES_${PN} += "clear-once"
+
+inherit obmc-phosphor-systemd
+inherit obmc-phosphor-license

--- a/meta-phosphor/common/recipes-phosphor/clear-once/clear-once/clear-once.service
+++ b/meta-phosphor/common/recipes-phosphor/clear-once/clear-once/clear-once.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Clear one time boot overrides
+
+ConditionFileNotEmpty=/etc/fw_env.config
+RequiresMountsFor=/run /sbin /etc
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+
+# It took 7 seconds to erase and write flash, be conservative
+TimeoutStartSec=60
+Restart=no
+
+ExecStart=/sbin/fw_setenv openbmconce

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -14,6 +14,7 @@ inherit obmc-phosphor-c-daemon
 
 TARGET_CFLAGS   += "-fpic"
 
+RDEPENDS_${PN} += "clear-once"
 RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid/host-ipmid.service
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid/host-ipmid.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Phosphor OpenBMC IPMI daemon
+Wants=clear-once.service
+After=clear-once.service
 
 [Service]
 ExecStart=/usr/sbin/ipmid

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -164,6 +164,11 @@ then
 	fsck=$fsckbase$rwfst
 fi
 
+if grep -w overlay-filesystem-in-ram $optfile
+then
+	rwfst=none
+fi
+
 if test -s /run/image-rofs
 then
 	rodev=/run/image-rofs

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -149,15 +149,14 @@ then
 	elif test -f $trigger -a ! -s $trigger
 	then
 		echo "Saving selected files from read-write overlay filesystem."
-		/update && rm -f $image*
+		/update --no-restore-files
 		echo "Clearing read-write overlay filesystem."
 		flash_eraseall /dev/$rwfs
 		echo "Restoring saved files to read-write overlay filesystem."
 		touch $trigger
-		/update 
-		rm -rf /save $trigger
+		/update --no-save-files --clean-saved-files
 	else
-		/update && rm -f $image*
+		/update --clean-saved-files
 	fi
 
 	rwfst=$(probe_fs_type $rwdev)

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -102,6 +102,7 @@ fsckbase=/sbin/fsck.
 fsck=$fsckbase$rwfst
 fsckopts=-a
 optfile=/run/initramfs/init-options
+update=/run/initramfs/update
 
 if test ! -f $optfile
 then
@@ -143,20 +144,20 @@ fi
 
 if ls $image* > /dev/null 2>&1
 then
-	if ! test -x /update
+	if ! test -x $update
 	then
-		debug_takeover "Flash update requested but /update missing!"
+		debug_takeover "Flash update requested but $update missing!"
 	elif test -f $trigger -a ! -s $trigger
 	then
 		echo "Saving selected files from read-write overlay filesystem."
-		/update --no-restore-files
+		$update --no-restore-files
 		echo "Clearing read-write overlay filesystem."
 		flash_eraseall /dev/$rwfs
 		echo "Restoring saved files to read-write overlay filesystem."
 		touch $trigger
-		/update --no-save-files --clean-saved-files
+		$update --no-save-files --clean-saved-files
 	else
-		/update --clean-saved-files
+		$update --clean-saved-files
 	fi
 
 	rwfst=$(probe_fs_type $rwdev)

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -183,12 +183,16 @@ then
 	then
 		debug_takeover "fsck of read-write fs on $rwdev failed (rc=$rc)"
 	fi
-elif test "$rwfst" != jffs2
+elif test "$rwfst" != jffs2 -a "$rwfst" != none
 then
 	echo "No '$fsck' in read only fs, skipping fsck."
 fi
 
-if ! mount $rwdev $rwdir -t $rwfst -o $rwopts
+if test "$rwfst" = none
+then
+	echo "Running with read-write overlay in RAM for this boot."
+	echo "No state will be preserved unless flash update performed."
+elif ! mount $rwdev $rwdir -t $rwfst -o $rwopts
 then
 	msg="$(cat)" << HERE
 

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -159,6 +159,12 @@ then
 	fsck=$fsckbase$rwfst
 fi
 
+if test -s /run/image-rofs
+then
+	rodev=/run/image-rofs
+	roopts=$roopts,loop
+fi
+
 mount $rodev $rodir -t $rofst -o $roopts
 
 if test -x $rodir$fsck

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -101,10 +101,16 @@ init=/sbin/init
 fsckbase=/sbin/fsck.
 fsck=$fsckbase$rwfst
 fsckopts=-a
+optfile=/run/initramfs/init-options
+
+if test ! -f $optfile
+then
+	cat /proc/cmdline > $optfile
+fi
 
 echo rofs = $rofs $rofst   rwfs = $rwfs $rwfst
 
-if grep -w debug-init-sh /proc/cmdline
+if grep -w debug-init-sh $optfile
 then
 	debug_takeover "Debug initial shell requested by command line."
 fi
@@ -118,7 +124,7 @@ then
 	mv /${imagebasename}* ${image%$imagebasename}
 fi
 
-if grep -w clean-rwfs-filesystem /proc/cmdline
+if grep -w clean-rwfs-filesystem $optfile
 then
 	echo "Cleaning of read-write overlay filesystem requested."
 	touch $trigger

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -115,13 +115,18 @@ then
 	debug_takeover "Debug initial shell requested by command line."
 fi
 
-# If there are images in root move them to run/initramfs/ now.
+# If there are images in root move them to /run/initramfs/ or /run/ now.
 imagebasename=${image##*/}
-if test -n "${imagebasename}" -a "x$flash_images_before_init" = xy &&
-	ls /${imagebasename}* > /dev/null 2>&1
+if test -n "${imagebasename}" && ls /${imagebasename}* > /dev/null 2>&1
 then
-	echo "Pending flash updates found."
-	mv /${imagebasename}* ${image%$imagebasename}
+	if test "x$flash_images_before_init" = xy
+	then
+		echo "Flash images found, will update before starting init."
+		mv /${imagebasename}* ${image%$imagebasename}
+	else
+		echo "Flash images found, will use but deferring flash update."
+		mv /${imagebasename}* /run/
+	fi
 fi
 
 if grep -w clean-rwfs-filesystem $optfile

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -183,7 +183,7 @@ then
 	then
 		debug_takeover "fsck of read-write fs on $rwdev failed (rc=$rc)"
 	fi
-elif test $fsck != /sbin/fsck.jffs2
+elif test "$rwfst" != jffs2
 then
 	echo "No '$fsck' in read only fs, skipping fsck."
 fi

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -117,6 +117,11 @@ fsckopts=-a
 optfile=/run/initramfs/init-options
 update=/run/initramfs/update
 
+if test -e /${optfile##*/}
+then
+	cp /${optfile##*/} $optfile
+fi
+
 if test ! -f $optfile
 then
 	cat /proc/cmdline > $optfile

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -169,6 +169,21 @@ then
 	rwfst=none
 fi
 
+copyfiles=
+if grep -w copy-files-to-ram $optfile
+then
+	rwfst=none
+	copyfiles=y
+fi
+
+# It would be nice to do this after fsck but that mean rofs is mounted
+# which triggers the mtd is mounted check
+if test "$rwfst$copyfiles" = noney
+then
+	touch $trigger
+	$update --copy-files --clean-saved-files --no-restore-files
+fi
+
 if grep -w copy-base-filesystem-to-ram $optfile &&
 	test ! -e /run/image-rofs && ! cp $rodev /run/image-rofs
 then

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-init.sh
@@ -169,6 +169,18 @@ then
 	rwfst=none
 fi
 
+if grep -w copy-base-filesystem-to-ram $optfile &&
+	test ! -e /run/image-rofs && ! cp $rodev /run/image-rofs
+then
+	# Remove any partial copy to avoid attempted usage later
+	if test -e  /run/image-rofs
+	then
+		ls -l /run/image-rofs
+		rm -f /run/image-rofs
+	fi
+	debug_takeover "Copying $rodev to /run/image-rofs failed."
+fi
+
 if test -s /run/image-rofs
 then
 	rodev=/run/image-rofs

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -43,7 +43,7 @@ if ls $image* > /dev/null 2>&1
 then
 	if test -x $update
 	then
-		$update
+		$update --clean-saved-files
 	else
 		echo 1>&2 "Flash update requested but $update program missing!"
 	fi

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -47,7 +47,7 @@ cat /proc/mounts
 
 test "$umount_proc" && umount /proc && rmdir /proc
 
-# ioctl(TIOC_DRAIN) to drain tty messages to console
+# tcsattr(tty, TIOCDRAIN, mode) to drain tty messages to console
 test -t 1 && stty cooked 0<&1
 
 # Execute the command systemd told us to ...

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -53,7 +53,7 @@ test -t 1 && stty cooked 0<&1
 # Execute the command systemd told us to ...
 if test -d /oldroot  && test "$1"
 then
-	if test "$1" == kexec
+	if test "$1" = kexec
 	then
 		$1 -f -e
 	else

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -30,7 +30,9 @@ do
 done
 set +x
 
+update=/run/initramfs/update
 image=/run/initramfs/image-
+
 if test -s /run/fw_env -a -c /run/mtd:u-boot-env -a ! -e ${image}u-boot-env &&
 	! cmp /run/mtd:u-boot-env /run/fw_env
 then
@@ -39,11 +41,11 @@ fi
 
 if ls $image* > /dev/null 2>&1
 then
-	if test -x /update
+	if test -x $update
 	then
-		/update
+		$update
 	else
-		echo 1>&2 "Flash update requested but /update program missing!"
+		echo 1>&2 "Flash update requested but $update program missing!"
 	fi
 fi
 

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -37,9 +37,14 @@ then
 	ln -sn /run/fw_env ${image}u-boot-env
 fi
 
-if test -x /update && ls $image* > /dev/null 2>&1
+if ls $image* > /dev/null 2>&1
 then
-	/update ${1+"$@"}
+	if test -x /update
+	then
+		/update
+	else
+		echo 1>&2 "Flash update requested but /update program missing!"
+	fi
 fi
 
 echo Remaining mounts:

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-shutdown.sh
@@ -45,7 +45,7 @@ fi
 echo Remaining mounts:
 cat /proc/mounts
 
-test "umount_proc" && umount /proc && rmdir /proc
+test "$umount_proc" && umount /proc && rmdir /proc
 
 # ioctl(TIOC_DRAIN) to drain tty messages to console
 test -t 1 && stty cooked 0<&1

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -138,8 +138,7 @@ for f in $image*
 do
 	m=$(findmtd ${f#$image})
 	echo "Updating ${f#$image}..."
-	# flasheraseall /dev/$m && dd if=$f of=/dev/$m
-	flashcp -v $f /dev/$m
+	flashcp -v $f /dev/$m && rm $f
 done
 
 if test "x$toram" = xy

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -136,6 +136,12 @@ done
 
 for f in $image*
 do
+	if test ! -s $f
+	then
+		echo "Skipping empty update of ${f#$image}."
+		rm $f
+		continue
+	fi
 	m=$(findmtd ${f#$image})
 	echo "Updating ${f#$image}..."
 	flashcp -v $f /dev/$m && rm $f

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -59,6 +59,7 @@ rwdir=/run/initramfs/rw
 upper=$rwdir/cow
 save=/run/save/${upper##*/}
 
+mounted=
 doclean=
 dosave=y
 dorestore=y
@@ -93,10 +94,14 @@ do
 	esac
 done
 
-if test "x$dosave" = xy -a -n "$rwfs"
+if test "x$dosave" = xy
 then
-	mkdir -p $rwdir
-	mount $rwdev $rwdir -t $(probe_fs_type $rwdev) -o $rorwopts
+	if test ! -d $upper -a -n "$rwfs"
+	then
+		mkdir -p $rwdir
+		mount $rwdev $rwdir -t $(probe_fs_type $rwdev) -o $rorwopts
+		mounted=$rwdir
+	fi
 
 	while read f
 	do
@@ -109,7 +114,10 @@ then
 		cp -rp $upper/$f "${d%/*}/"
 	done < $whitelist
 
-	umount $rwdir
+	if test -n "$mounted"
+	then
+		umount $mounted
+	fi
 fi
 
 for f in $image*

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -55,7 +55,7 @@ rwdev=/dev/mtdblock${rwfs#mtd}
 rwopts=rw
 rorwopts=ro${rwopts#rw}
 
-rwdir=rw
+rwdir=/run/initramfs/rw
 upper=$rwdir/cow
 save=/run/save/${upper##*/}
 

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -59,6 +59,23 @@ rwdir=rw
 upper=$rwdir/cow
 save=save/${upper##*/}
 
+doclean=
+
+while test "$1" != "${1#-}"
+do
+	case "$1" in
+	--no-clean-saved-files)
+		doclean=
+		shift ;;
+	--clean-saved-files)
+		doclean=y
+		shift ;;
+	*)
+		echo 2>&1 "Unknown option $1"
+		exit 1 ;;
+	esac
+done
+
 if test -n "$rwfs" && test -s whitelist
 then
 
@@ -103,6 +120,11 @@ then
 	mount $rwdev $rwdir -t $(probe_fs_type $rwdev) -o $rwopts
 	cp -rp $save/. $upper/
 	umount $rwdir
+fi
+
+if test "x$doclean" = xy
+then
+	rm -rf $save
 fi
 
 exit

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -63,6 +63,7 @@ mounted=
 doclean=
 dosave=y
 dorestore=y
+toram=
 
 whitelist=/run/initramfs/whitelist
 image=/run/initramfs/image-
@@ -87,6 +88,9 @@ do
 		shift ;;
 	--restore-files)
 		dorestore=y
+		shift ;;
+	--copy-files)
+		toram=y
 		shift ;;
 	*)
 		echo 2>&1 "Unknown option $1"
@@ -137,6 +141,12 @@ do
 	# flasheraseall /dev/$m && dd if=$f of=/dev/$m
 	flashcp -v $f /dev/$m
 done
+
+if test "x$toram" = xy
+then
+	mkdir -p $upper
+	cp -rp $save/. $upper/
+fi
 
 if test -d $save -a "x$dorestore" = xy
 then

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -132,9 +132,15 @@ done
 
 if test -d $save -a "x$dorestore" = xy
 then
+	odir=$rwdir
+	rwdir=/run/rw
+	upper=$rwdir${upper#$odir}
+
+	mkdir -p $rwdir
 	mount $rwdev $rwdir -t $(probe_fs_type $rwdev) -o $rwopts
 	cp -rp $save/. $upper/
 	umount $rwdir
+	rmdir $rwdir
 fi
 
 if test "x$doclean" = xy

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -63,6 +63,9 @@ doclean=
 dosave=y
 dorestore=y
 
+whitelist=/run/initramfs/whitelist
+image=/run/initramfs/image-
+
 while test "$1" != "${1#-}"
 do
 	case "$1" in
@@ -104,12 +107,11 @@ then
 		d="$save/$f"
 		mkdir -p "${d%/*}"
 		cp -rp $upper/$f "${d%/*}/"
-	done < whitelist
+	done < $whitelist
 
 	umount $rwdir
 fi
 
-image=/run/initramfs/image-
 for f in $image*
 do
 	m=$(findmtd ${f#$image})

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -60,6 +60,8 @@ upper=$rwdir/cow
 save=save/${upper##*/}
 
 doclean=
+dosave=y
+dorestore=y
 
 while test "$1" != "${1#-}"
 do
@@ -70,15 +72,26 @@ do
 	--clean-saved-files)
 		doclean=y
 		shift ;;
+	--no-save-files)
+		dosave=
+		shift ;;
+	--save-files)
+		dosave=y
+		shift ;;
+	--no-restore-files)
+		dorestore=
+		shift ;;
+	--restore-files)
+		dorestore=y
+		shift ;;
 	*)
 		echo 2>&1 "Unknown option $1"
 		exit 1 ;;
 	esac
 done
 
-if test -n "$rwfs" && test -s whitelist
+if test "x$dosave" = xy -a -n "$rwfs" -a -s whitelist
 then
-
 	mkdir -p $rwdir
 	mount $rwdev $rwdir -t $(probe_fs_type $rwdev) -o $rorwopts
 
@@ -115,7 +128,7 @@ do
 	flashcp -v $f /dev/$m
 done
 
-if test -d $save
+if test -d $save -a "x$dorestore" = xy
 then
 	mount $rwdev $rwdir -t $(probe_fs_type $rwdev) -o $rwopts
 	cp -rp $save/. $upper/

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -90,7 +90,7 @@ do
 	esac
 done
 
-if test "x$dosave" = xy -a -n "$rwfs" -a -s whitelist
+if test "x$dosave" = xy -a -n "$rwfs"
 then
 	mkdir -p $rwdir
 	mount $rwdev $rwdir -t $(probe_fs_type $rwdev) -o $rorwopts

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -138,6 +138,7 @@ then
 
 	mkdir -p $rwdir
 	mount $rwdev $rwdir -t $(probe_fs_type $rwdev) -o $rwopts
+	mkdir -p $upper
 	cp -rp $save/. $upper/
 	umount $rwdir
 	rmdir $rwdir

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/files/obmc-update.sh
@@ -57,7 +57,7 @@ rorwopts=ro${rwopts#rw}
 
 rwdir=rw
 upper=$rwdir/cow
-save=save/${upper##*/}
+save=/run/save/${upper##*/}
 
 doclean=
 dosave=y

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/obmc-phosphor-init.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-initfs/obmc-phosphor-init.bb
@@ -12,6 +12,13 @@ SRC_URI += "file://obmc-update.sh"
 SRC_URI += "file://whitelist"
 
 do_install() {
+	for f in init-download-url init-options
+	do
+		if test -e $f
+		then
+			install -m 0755 ${WORKDIR}/$f ${D}/$f
+		fi
+	done
         install -m 0755 ${WORKDIR}/obmc-init.sh ${D}/init
         install -m 0755 ${WORKDIR}/obmc-shutdown.sh ${D}/shutdown
         install -m 0755 ${WORKDIR}/obmc-update.sh ${D}/update
@@ -21,3 +28,4 @@ do_install() {
 }
 
 FILES_${PN} += " /init /shutdown /update /whitelist /dev "
+FILES_${PN} += " /init-options /init-download-url "


### PR DESCRIPTION
This series adds support to the openbmc phosphor initfs scripts to support the BMC running with either or both of the read-write and read-only layers of the root file system to be in RAM instead of in the flash.
This decision is made via u-boot firmware variables and the kernel command line, and is designed to have a persistent and one time option.

Also included is a systemd service called clear-once that clears the variable meant for one time use.  The host-ipmid service is modified to want to run after the clear-once service in anticipation of the a OEM command that will set the variable.

When running in RAM the read-write layer can be replaced with updated content.  If both layers are in memory the BMC will not be accessing the flash except by explicit action, which include a shutdown and reboot.

This series includes support to copy the read-only layer from the existing flash at boot, and to copy the white listed files from the read-write file system at boot and restore them at shutdown along with the u-boot environment.  Also included is support for using images sourced from elsewhere either by manual intervention at the debug-init-sh shell prompt or via a shell command line stored in a u-boot environment variable (only executed if an option is found on the command line or in the previously mentioned u-boot variables).  This can be used to download the read-only layer from the network to test or run a new read-only layer while updating the flash.  The packaged initfs supports HTTP ant TFTP transfers via the busybox commands.

The updated flash update script can run while the BMC is at system runtime if both layers are in RAM.  Future updates will allow it to update one layer while the other is mounted.  The error handling in the update script still is designed for use at shutdown with a console to debug and fix unexpected conditions.  Future updates could also support leaving the watchdog timer enabled during flash, but a reset during an update to u-boot will always be fatal without a redundant flash chip and the corresponding strapping and support.

The options and variable names were listed in this prior email https://lists.ozlabs.org/pipermail/openbmc/2016-March/002119.html


. Documentation for this and network booting will be written.
