### PR TITLE
Add palmetto target to runqemu

### DIFF
--- a/meta-openbmc-bsp/conf/layer.conf
+++ b/meta-openbmc-bsp/conf/layer.conf
@@ -1,0 +1,8 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+# We have a recipes directory containing .bb and .bbappend files, add to BBFILES
+BBFILES := "${BBFILES} ${LAYERDIR}/recipes*/*/*.bb \ ${LAYERDIR}/recipes*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "openbmc-bsp"
+BBFILE_PATTERN_openbmc-bsp = ""
+BBFILE_PRIORITY = "1"

--- a/meta-openbmc-bsp/recipes-devtools/qemu/qemu-targets.inc
+++ b/meta-openbmc-bsp/recipes-devtools/qemu/qemu-targets.inc
@@ -1,0 +1,22 @@
+# possible arch values are arm aarch64 mips mipsel mips64 mips64el ppc ppc64 ppc64abi32
+# ppcemb armeb alpha sparc32plus i386 x86_64 cris m68k microblaze sparc sparc32
+# sparc32plus
+
+def get_qemu_target_list(d):
+    import bb
+    archs = d.getVar('QEMU_TARGETS', True).split()
+    tos = d.getVar('HOST_OS', True)
+    softmmuonly = ""
+    for arch in ['mips64', 'mips64el', 'ppcemb']:
+        if arch in archs:
+            softmmuonly += arch + "-softmmu,"
+            archs.remove(arch)
+    linuxuseronly = ""
+    for arch in ['armeb', 'alpha', 'ppc64abi32', 'sparc32plus']:
+        if arch in archs:
+            linuxuseronly += arch + "-linux-user,"
+            archs.remove(arch)
+    if 'linux' not in tos:
+        return softmmuonly + ''.join([arch + "-softmmu" + "," for arch in archs]).rstrip(',')
+    return softmmuonly + linuxuseronly + ''.join([arch + "-linux-user" + "," + arch + "-softmmu" + "," for arch in archs]).rstrip(',')
+

--- a/meta-openbmc-bsp/recipes-devtools/qemu/qemu.inc
+++ b/meta-openbmc-bsp/recipes-devtools/qemu/qemu.inc
@@ -1,0 +1,125 @@
+SUMMARY = "Fast open source processor emulator"
+HOMEPAGE = "http://qemu.org"
+LICENSE = "GPLv2 & LGPLv2.1"
+DEPENDS = "glib-2.0 zlib pixman"
+RDEPENDS_${PN}_class-target += "bash python"
+RDEPENDS_${PN}-ptest = "bash make"
+
+require qemu-targets.inc
+inherit autotools ptest
+BBCLASSEXTEND = "native nativesdk"
+
+PR = "r0"
+
+# QEMU_TARGETS is overridable variable
+QEMU_TARGETS ?= "arm aarch64 i386 mips mipsel mips64 mips64el ppc sh4 x86_64"
+
+EXTRA_OECONF += "--target-list=${@get_qemu_target_list(d)} --disable-werror  --disable-bluez --disable-libiscsi --with-system-pixman --extra-cflags='${CFLAGS}'"
+
+EXTRA_OECONF_append_class-native = " --enable-debug --enable-debug-info"
+INHIBIT_SYSROOT_STRIP = "1"
+
+EXTRA_OECONF_class-nativesdk = "--target-list=${@get_qemu_target_list(d)} --disable-werror \
+				"
+export LIBTOOL="${HOST_SYS}-libtool"
+
+do_configure_prepend_class-native() {
+	# Append build host pkg-config paths for native target since the host may provide sdl
+	BHOST_PKGCONFIG_PATH=$(PATH=/usr/bin:/bin pkg-config --variable pc_path pkg-config || echo "")
+	if [ ! -z "$BHOST_PKGCONFIG_PATH" ]; then
+		export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:$BHOST_PKGCONFIG_PATH
+		# link with system dbus on Ubuntu 15.10
+		# FIXME: remove below 4 lines when oe dbus is upgraded
+		if [ -r /etc/lsb-release -a "$(lsb_release -is)$(lsb_release -rs)" = "Ubuntu15.10" ] ; then
+			libs=$(PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_PATH=$BHOST_PKGCONFIG_PATH PATH=/usr/bin:/bin pkg-config --libs dbus-1 || echo "")
+			[ -n "$libs" ] && export LDFLAGS="$libs $LDFLAGS"
+		fi
+	fi
+}
+
+KVMENABLE = "--enable-kvm"
+KVMENABLE_darwin = "--disable-kvm"
+KVMENABLE_mingw32 = "--disable-kvm"
+
+do_configure() {
+    # Handle distros such as CentOS 5 32-bit that do not have kvm support
+    KVMOPTS="--disable-kvm"
+    if [ "${PN}" != "qemu-native" -a "${PN}" != "nativesdk-qemu" ] \
+       || [ -f /usr/include/linux/kvm.h ] ; then
+       KVMOPTS="${KVMENABLE}"
+    fi
+
+    ${S}/configure --prefix=${prefix} --sysconfdir=${sysconfdir} --libexecdir=${libexecdir} --localstatedir=${localstatedir} --disable-strip ${EXTRA_OECONF} $KVMOPTS
+    test ! -e ${S}/target-i386/beginend_funcs.sh || chmod a+x ${S}/target-i386/beginend_funcs.sh
+}
+
+do_compile_ptest() {
+	make buildtest-TESTS
+}
+
+do_install_ptest() {
+	cp -rL ${B}/tests ${D}${PTEST_PATH}
+	find ${D}${PTEST_PATH}/tests -type f -name "*.[Sshcod]" | xargs -i rm -rf {}
+
+	cp ${S}/tests/Makefile ${D}${PTEST_PATH}/tests
+}
+
+do_install () {
+	export STRIP="true"
+	autotools_do_install
+	install -d ${D}${datadir}/qemu
+}
+
+# The following fragment will create a wrapper for qemu-mips user emulation
+# binary in order to work around a segmentation fault issue. Basically, by
+# default, the reserved virtual address space for 32-on-64 bit is set to 4GB.
+# This will trigger a MMU access fault in the virtual CPU. With this change,
+# the qemu-mips works fine.
+# IMPORTANT: This piece needs to be removed once the root cause is fixed!
+do_install_append() {
+	if [ -e "${D}/${bindir}/qemu-mips" ]; then
+		create_wrapper ${D}/${bindir}/qemu-mips \
+			QEMU_RESERVED_VA=0x0
+	fi
+}
+# END of qemu-mips workaround
+
+PACKAGECONFIG ??= " \
+	fdt sdl \
+	${@bb.utils.contains('DISTRO_FEATURES', 'alsa', 'alsa', '', d)} \
+	${@bb.utils.contains('DISTRO_FEATURES', 'xen', 'xen', '', d)} \
+	"
+PACKAGECONFIG_class-native ??= "fdt alsa uuid"
+PACKAGECONFIG_class-nativesdk ??= "fdt sdl"
+NATIVEDEPS = ""
+NATIVEDEPS_class-native = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'libxext-native', '',d)}"
+PACKAGECONFIG[sdl] = "--enable-sdl,--disable-sdl,libsdl ${NATIVEDEPS},"
+PACKAGECONFIG[virtfs] = "--enable-virtfs --enable-attr,--disable-virtfs,libcap attr,"
+PACKAGECONFIG[aio] = "--enable-linux-aio,--disable-linux-aio,libaio,"
+PACKAGECONFIG[xfs] = "--enable-xfsctl,--disable-xfsctl,xfsprogs,"
+PACKAGECONFIG[xen] = "--enable-xen,--disable-xen,xen,xen-libxenstore xen-libxenctrl xen-libxenguest"
+PACKAGECONFIG[vnc-sasl] = "--enable-vnc --enable-vnc-sasl,--disable-vnc-sasl,cyrus-sasl,"
+PACKAGECONFIG[vnc-jpeg] = "--enable-vnc --enable-vnc-jpeg,--disable-vnc-jpeg,jpeg,"
+PACKAGECONFIG[vnc-png] = "--enable-vnc --enable-vnc-png,--disable-vnc-png,libpng,"
+PACKAGECONFIG[libcurl] = "--enable-curl,--disable-curl,libcurl,"
+PACKAGECONFIG[uuid] = "--enable-uuid,--disable-uuid,util-linux,"
+PACKAGECONFIG[curses] = "--enable-curses,--disable-curses,ncurses,"
+PACKAGECONFIG[gtk+] = "--enable-gtk --enable-vte,--disable-gtk --disable-vte,gtk+ libvte,"
+PACKAGECONFIG[libcap-ng] = "--enable-cap-ng,--disable-cap-ng,libcap-ng,"
+PACKAGECONFIG[ssh2] = "--enable-libssh2,--disable-libssh2,libssh2,"
+PACKAGECONFIG[libusb] = "--enable-libusb,--disable-libusb,libusb1"
+PACKAGECONFIG[fdt] = "--enable-fdt,--disable-fdt,dtc"
+PACKAGECONFIG[alsa] = ",,alsa-lib"
+PACKAGECONFIG[glx] = "--enable-opengl,--disable-opengl,mesa"
+PACKAGECONFIG[lzo] = "--enable-lzo,--disable-lzo,lzo"
+PACKAGECONFIG[numa] = "--enable-numa,--disable-numa,numactl"
+PACKAGECONFIG[gnutls] = "--enable-gnutls,--disable-gnutls,gnutls"
+
+EXTRA_OECONF += "${@bb.utils.contains('PACKAGECONFIG', 'alsa', '--audio-drv-list=oss,alsa', '', d)}"
+
+# Qemu target will not build in world build for ARM or Mips
+BROKEN_qemuarm = "1"
+BROKEN_qemumips64 = "1"
+BROKEN_qemumips = "1"
+
+INSANE_SKIP_${PN} = "arch"

--- a/meta-openbmc-bsp/recipes-devtools/qemu/qemu_git.bb
+++ b/meta-openbmc-bsp/recipes-devtools/qemu/qemu_git.bb
@@ -1,0 +1,21 @@
+# Based off of [1], appears to be MIT licensed [2].
+#
+# [1] https://github.com/dirtybit/gumstix-yocto/blob/master/meta/recipes-devtools/qemu/qemu_git.bb
+# [2] https://github.com/dirtybit/gumstix-yocto/blob/master/meta/COPYING.MIT
+
+require qemu.inc
+
+SRCREV = "d1f8764099022bc1173f2413331b26d4ff609a0c"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=441c28d2cf86e15a37fa47e15a72fbac \
+                    file://COPYING.LIB;endline=24;md5=c04def7ae38850e7d3ef548588159913"
+
+SRC_URI = "git://github.com/openbmc/qemu.git;protocol=https"
+S = "${WORKDIR}/git"
+
+COMPATIBLE_HOST_class-target_mips64 = "null"
+
+do_install_append() {
+    # Prevent QA warnings about installed ${localstatedir}/run
+    if [ -d ${D}${localstatedir}/run ]; then rmdir ${D}${localstatedir}/run; fi
+}

--- a/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/conf/bblayers.conf.sample
+++ b/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/conf/bblayers.conf.sample
@@ -9,6 +9,7 @@ BBLAYERS ?= " \
   ##OEROOT##/meta \
   ##OEROOT##/meta-yocto \
   ##OEROOT##/meta-phosphor \
+  ##OEROOT##/meta-openbmc-bsp \
   ##OEROOT##/meta-openbmc-bsp/meta-aspeed \
   ##OEROOT##/meta-openbmc-bsp/meta-aspeed/meta-ast2400 \
   ##OEROOT##/meta-openbmc-machines/meta-openpower \

--- a/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/conf/conf-notes.txt
+++ b/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/conf/conf-notes.txt
@@ -1,2 +1,5 @@
 Common targets are:
      obmc-phosphor-image
+
+You can also run generated images with qemu:
+     runqemu palmetto

--- a/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/conf/bblayers.conf.sample
+++ b/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/conf/bblayers.conf.sample
@@ -9,6 +9,7 @@ BBLAYERS ?= " \
   ##OEROOT##/meta \
   ##OEROOT##/meta-yocto \
   ##OEROOT##/meta-phosphor \
+  ##OEROOT##/meta-openbmc-bsp \
   ##OEROOT##/meta-openbmc-bsp/meta-aspeed \
   ##OEROOT##/meta-openbmc-bsp/meta-aspeed/meta-ast2400 \
   ##OEROOT##/meta-openbmc-machines/meta-openpower \

--- a/yocto-poky/scripts/runqemu
+++ b/yocto-poky/scripts/runqemu
@@ -110,7 +110,7 @@ while true; do
     arg=${1}
     case "$arg" in
         "qemux86" | "qemux86-64" | "qemuarm" | "qemuarm64" | "qemumips" | "qemumipsel" | \
-        "qemumips64" | "qemush4"  | "qemuppc" | "qemumicroblaze" | "qemuzynq")
+        "qemumips64" | "qemush4"  | "qemuppc" | "qemumicroblaze" | "qemuzynq" | "palmetto")
             [ -z "$MACHINE" ] && MACHINE=$arg || \
                 error "conflicting MACHINE types [$MACHINE] and [$arg]"
             ;;
@@ -236,13 +236,13 @@ fi
 
 if [ -z "$MACHINE" ]; then
     if [ "x$FSTYPE" = "xvmdk" ] || [ "x$FSTYPE" = "xhddimg" ] || [ "x$FSTYPE" = "xhdddirect" ]; then
-        MACHINE=`basename $VM | sed -n 's/.*\(qemux86-64\|qemux86\|qemuarm64\|qemuarm\|qemumips64\|qemumips\|qemuppc\|qemush4\).*/\1/p'`
+        MACHINE=`basename $VM | sed -n 's/.*\(qemux86-64\|qemux86\|qemuarm64\|qemuarm\|qemumips64\|qemumips\|qemuppc\|qemush4|palmetto\).*/\1/p'`
         if [ -z "$MACHINE" ]; then
             error "Unable to set MACHINE from image filename [$VM]"
         fi
         echo "Set MACHINE to [$MACHINE] based on image [$VM]"
     else
-        MACHINE=`basename $KERNEL | sed -n 's/.*\(qemux86-64\|qemux86\|qemuarm64\|qemuarm\|qemumips64\|qemumips\|qemuppc\|qemush4\).*/\1/p'`
+        MACHINE=`basename $KERNEL | sed -n 's/.*\(qemux86-64\|qemux86\|qemuarm64\|qemuarm\|qemumips64\|qemumips\|qemuppc\|qemush4|palmetto\).*/\1/p'`
         if [ -z "$MACHINE" ]; then
             error "Unable to set MACHINE from kernel filename [$KERNEL]"
         fi
@@ -331,6 +331,9 @@ QEMUMICROBLAZE_DEFAULT_FSTYPE=cpio
 
 QEMUZYNQ_DEFAULT_KERNEL=uImage
 QEMUZYNQ_DEFAULT_FSTYPE=cpio
+
+PALMETTO_DEFAULT_KERNEL=cuImage
+PALMETTO_DEFAULT_FSTYPE=cpio.gz
 
 AKITA_DEFAULT_KERNEL=zImage-akita.bin
 AKITA_DEFAULT_FSTYPE=jffs2

--- a/yocto-poky/scripts/runqemu-internal
+++ b/yocto-poky/scripts/runqemu-internal
@@ -53,6 +53,9 @@ else
         "qemuarm64")
             mem_size=512
             ;;
+        "palmetto")
+            mem_size=512
+            ;;
         "qemumicroblaze")
             mem_size=64
             ;;
@@ -295,6 +298,7 @@ fi
 
 case "$MACHINE" in
     "qemuarm") ;;
+    "palmetto") ;;
     "qemuarm64") ;;
     "qemumicroblaze") ;;
     "qemumips") ;;
@@ -382,6 +386,14 @@ if [ "$MACHINE" = "qemuarm" -o "$MACHINE" = "qemuarmv6" -o "$MACHINE" = "qemuarm
     if [ "$MACHINE" = "qemuarmv7" ]; then
         QEMUOPTIONS="$QEMUOPTIONS -cpu cortex-a8"
     fi
+fi
+
+if [ "$MACHINE" = "palmetto" ]; then
+    QEMU=qemu-system-arm
+    MACHINE_SUBTYPE=palmetto-bmc
+    export QEMU_AUDIO_DRV="none"
+    KERNCMDLINE="console=ttyS4"
+    QEMUOPTIONS="$QEMU_NETWORK_CMD -M ${MACHINE_SUBTYPE} -initrd $ROOTFS -no-reboot -nographic"
 fi
 
 if [ "$MACHINE" = "qemuarm64" ]; then


### PR DESCRIPTION
The patches modelling a bare-bones AST2400 in QEMU have been merged into
master for the upcoming 2.6 release. Attached is an attempt at integrating the
necessary bits into openbmc so we can `bitbake obmc-phosphor-image` then
`runqemu palmetto` to boot the BMC kernel and some representation of the
userspace.

There's no networking, but I'll be taking a look at how difficult adding some
support might be. I've also asked in #yocto about if there's a better way to
add the palmetto support to runqemu but haven't had a reply. I'll ask on the
mailing list if that query goes unanswered, but from the way the scripts are
written it doesn't look like there is much alternative.

Cheers,

Andrew

PS: qemu doesn't terminate if you `poweroff`. To kill it, issue 'Ctrl-A c' to
switch to the monitor, then 'quit'.

Since the initial RFC:

  * Split the patch in two: add qemu_git.bb, then modify runqemu
  * Don't supplant yocto-poky qemu_2.4.0.bb
  * Change qemu_git.bb's fetch URL to avoid failures and add flexibility
  * Add a note about invoking `runqemu palmetto` on oe-init-build-env

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/210)
<!-- Reviewable:end -->
