### PR TITLE
inarp: Update to 19ed5170

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/inarp/inarp.bb
+++ b/meta-phosphor/common/recipes-phosphor/inarp/inarp.bb
@@ -11,7 +11,7 @@ TARGET_CFLAGS   += "-fpic -O2"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/inarp"
 
-SRCREV = "19ed5170356495f5fc67189513c5739780ee6a81"
+SRCREV = "e3f27cf06cc2ca93ae9746ba705a0d9fc307cec2"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "inarp"


### PR DESCRIPTION
This change updates us to 19ed5170, which supports dynamic interface
configuration, and better syslog support.

Jeremy Kerr (3):
      Rename inarp_ctx.socket
      Use netlink for link state queries
      Use syslog for log output

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/211)
<!-- Reviewable:end -->
