### PR TITLE
Limit size of event log db

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/files/obmc-phosphor-event.service
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/files/obmc-phosphor-event.service
@@ -2,7 +2,7 @@
 Description=Phosphor OpenBMC event management daemon
 
 [Service]
-ExecStart=/usr/sbin/obmc-phosphor-eventd
+ExecStart=/usr/sbin/obmc-phosphor-eventd -s 200000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The event log process now supports an argument to specify the max
size of the event log db. Set this size to a default of 200kB.

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/214)
<!-- Reviewable:end -->
