### PR TITLE
Add obmc-console project

### DIFF
--- a/meta-phosphor/classes/obmc-phosphor-image.bbclass
+++ b/meta-phosphor/classes/obmc-phosphor-image.bbclass
@@ -42,6 +42,7 @@ IMAGE_INSTALL += " \
         i2c-tools \
         screen \
         inarp \
+        obmc-console \
         "
 
 def build_overlay(d):

--- a/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console.bb
@@ -1,0 +1,21 @@
+SUMMARY = "OpenBMC console daemon"
+DESCRIPTION = "Daemon to handle UART console connections"
+HOMEPAGE = "http://github.com/openbmc/obmc-console"
+PR = "r1"
+
+inherit obmc-phosphor-license
+inherit obmc-phosphor-systemd
+inherit autotools
+
+TARGET_CFLAGS   += "-fpic -O2"
+
+SRC_URI += "git://github.com/openbmc/obmc-console"
+SRC_URI += "file://${PN}.conf"
+SRCREV = "54e9569d14b127806e45e1c17ec4a1f5f7271d3f"
+
+do_install_append() {
+        install -m 0755 -d ${D}${sysconfdir}
+        install -m 0644 ${WORKDIR}/${PN}.conf ${D}${sysconfdir}/${PN}.conf
+}
+
+S = "${WORKDIR}/git"

--- a/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console/obmc-console.conf
+++ b/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console/obmc-console.conf
@@ -1,0 +1,3 @@
+device = ttyS5
+lpc-address = 0x3f8
+sirq = 4

--- a/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console/obmc-console.service
+++ b/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console/obmc-console.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=OpenBMC console daemon
+
+[Service]
+ExecStart=/usr/sbin/obmc-console-server
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This change introduces obmc-console, a little daemon to handle the UART
data and multiplex it to a log and client processes.

Signed-off-by: Jeremy Kerr <jk@ozlabs.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/215)
<!-- Reviewable:end -->
