### PR TITLE
Re-enable obmc-console and add a ssh endpoint

### DIFF
--- a/meta-phosphor/classes/obmc-phosphor-image.bbclass
+++ b/meta-phosphor/classes/obmc-phosphor-image.bbclass
@@ -42,6 +42,7 @@ IMAGE_INSTALL += " \
         i2c-tools \
         screen \
         inarp \
+        obmc-console \
         "
 
 def build_overlay(d):

--- a/meta-phosphor/common/recipes-core/dropbear/dropbear/0001-dropbear-Add-c-command-option-to-force-a-specific-co.patch
+++ b/meta-phosphor/common/recipes-core/dropbear/dropbear/0001-dropbear-Add-c-command-option-to-force-a-specific-co.patch
@@ -1,0 +1,91 @@
+From b4e094381ec846f4387dc6a3c210c2205a8db58a Mon Sep 17 00:00:00 2001
+From: Jeremy Kerr <jk@ozlabs.org>
+Date: Tue, 12 Apr 2016 11:11:40 +0800
+Subject: [PATCH] dropbear: Add -c <command> option to force a specific command
+
+This change adds a -c option to dropbear, to force the session to use a
+specific command, in a similar fashion to OpenSSH's ForceCommand
+configuration option.
+
+This is useful to provide a simple fixed service over ssh, without
+requiring an authorized key file for the per-key forced_command option.
+
+This setting takes precedence over the channel session's provided
+command, and the per-key forced_command setting.
+
+Signed-off-by: Jeremy Kerr <jk@ozlabs.org>
+---
+ runopts.h         |  2 ++
+ svr-chansession.c | 12 ++++++++++--
+ svr-runopts.c     |  5 +++++
+ 3 files changed, 17 insertions(+), 2 deletions(-)
+
+diff --git a/runopts.h b/runopts.h
+index f7c869d..ffb573e 100644
+--- a/runopts.h
++++ b/runopts.h
+@@ -114,6 +114,8 @@ typedef struct svr_runopts {
+ 	buffer * banner;
+ 	char * pidfile;
+ 
++	char * command;
++
+ } svr_runopts;
+ 
+ extern svr_runopts svr_opts;
+diff --git a/svr-chansession.c b/svr-chansession.c
+index bfaf7f6..d6c9330 100644
+--- a/svr-chansession.c
++++ b/svr-chansession.c
+@@ -671,8 +671,16 @@ static int sessioncommand(struct Channel *channel, struct ChanSess *chansess,
+ 		}
+ 	}
+ 	
+-	/* take public key option 'command' into account */
+-	svr_pubkey_set_forced_command(chansess);
++
++	/* take global command into account */
++	if (svr_opts.command) {
++		chansess->original_command = chansess->cmd ? : m_strdup("");
++		chansess->cmd = m_strdup(svr_opts.command);
++	} else {
++		/* take public key option 'command' into account */
++		svr_pubkey_set_forced_command(chansess);
++	}
++
+ 
+ #ifdef LOG_COMMANDS
+ 	if (chansess->cmd) {
+diff --git a/svr-runopts.c b/svr-runopts.c
+index 8f60059..f845300 100644
+--- a/svr-runopts.c
++++ b/svr-runopts.c
+@@ -79,6 +79,7 @@ static void printhelp(const char * progname) {
+ #ifdef ENABLE_SVR_REMOTETCPFWD
+ 					"-k		Disable remote port forwarding\n"
+ 					"-a		Allow connections to forwarded ports from any host\n"
++					"-c command	Force executed command\n"
+ #endif
+ 					"-p [address:]port\n"
+ 					"		Listen on specified tcp port (and optionally address),\n"
+@@ -125,6 +126,7 @@ void svr_getopts(int argc, char ** argv) {
+ 	/* see printhelp() for options */
+ 	svr_opts.bannerfile = NULL;
+ 	svr_opts.banner = NULL;
++	svr_opts.command = NULL;
+ 	svr_opts.forkbg = 1;
+ 	svr_opts.norootlogin = 0;
+ 	svr_opts.noauthpass = 0;
+@@ -177,6 +179,9 @@ void svr_getopts(int argc, char ** argv) {
+ 				case 'b':
+ 					next = &svr_opts.bannerfile;
+ 					break;
++				case 'c':
++					next = &svr_opts.command;
++					break;
+ 				case 'd':
+ 				case 'r':
+ 					next = &keyfile;
+-- 
+2.5.0
+

--- a/meta-phosphor/common/recipes-core/dropbear/dropbear_%.bbappend
+++ b/meta-phosphor/common/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,2 +1,3 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI += "file://dropbearkey.service"
+SRC_URI += "file://dropbearkey.service \
+	    file://0001-dropbear-Add-c-command-option-to-force-a-specific-co.patch"

--- a/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console.bb
@@ -10,12 +10,30 @@ inherit autotools
 TARGET_CFLAGS   += "-fpic -O2"
 
 SRC_URI += "git://github.com/openbmc/obmc-console"
-SRC_URI += "file://${PN}.conf"
+SRC_URI += "file://${PN}.conf \
+	    file://obmc-console-ssh.socket \
+	    file://obmc-console-ssh@.service"
+
 SRCREV = "2eacda524e98c7964e542e01aabf82360cf60344"
+
+FILES_${PN} += "${systemd_unitdir}/system/obmc-console-ssh@.service \
+		${systemd_unitdir}/system/obmc-console-ssh.socket"
+
+SYSTEMD_SERVICE_${PN} = "${BPN}.service ${BPN}-ssh.socket"
 
 do_install_append() {
         install -m 0755 -d ${D}${sysconfdir}
         install -m 0644 ${WORKDIR}/${PN}.conf ${D}${sysconfdir}/${PN}.conf
+
+	# add additional unit files for ssh-based console server
+	install -d ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/obmc-console-ssh@.service ${D}${systemd_unitdir}/system
+	install -m 0644 ${WORKDIR}/obmc-console-ssh.socket ${D}${systemd_unitdir}/system
+	sed -i -e 's,@BASE_BINDIR@,${base_bindir},g' \
+		-e 's,@BINDIR@,${bindir},g' \
+		-e 's,@SBINDIR@,${sbindir},g' \
+		${D}${systemd_unitdir}/system/obmc-console-ssh@.service \
+		${D}${systemd_unitdir}/system/obmc-console-ssh.socket
 }
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console.bb
@@ -11,7 +11,7 @@ TARGET_CFLAGS   += "-fpic -O2"
 
 SRC_URI += "git://github.com/openbmc/obmc-console"
 SRC_URI += "file://${PN}.conf"
-SRCREV = "54e9569d14b127806e45e1c17ec4a1f5f7271d3f"
+SRCREV = "2eacda524e98c7964e542e01aabf82360cf60344"
 
 do_install_append() {
         install -m 0755 -d ${D}${sysconfdir}

--- a/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console/obmc-console-ssh.socket
+++ b/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console/obmc-console-ssh.socket
@@ -1,0 +1,11 @@
+[Unit]
+Description=OpenBMC console ssh server socket
+Conflicts=obmc-console-ssh.service
+Requires=obmc-console.service
+
+[Socket]
+ListenStream=2200
+Accept=yes
+
+[Install]
+WantedBy=sockets.target

--- a/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console/obmc-console-ssh@.service
+++ b/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console/obmc-console-ssh@.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=OBMC console SSH Per-Connection Server
+Wants=obmc-console.service
+
+[Service]
+Environment="DROPBEAR_RSAKEY_DIR=/etc/dropbear"
+EnvironmentFile=-/etc/default/dropbear
+ExecStart=-@SBINDIR@/dropbear -i -r ${DROPBEAR_RSAKEY_DIR}/dropbear_rsa_host_key -c @BINDIR@/obmc-console-client $DROPBEAR_EXTRA_ARGS
+ExecReload=@BASE_BINDIR@/kill -HUP $MAINPID
+StandardInput=socket
+KillMode=process


### PR DESCRIPTION
Following the previous disable, this bumps us to a working obmc-console version, and adds infrastructure for a ssh-based remote console connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/232)
<!-- Reviewable:end -->
