### PR TITLE
Recipe updates for Network, Skeleton, Event, IPMI

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -19,7 +19,7 @@ RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = "b7e01a16951e868b076f3d68ecb0688a5209aa5b"
+SRCREV = "2bcf128699eaff43f4bd4084ab4096d49d782b6b"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "ipmid"

--- a/meta-phosphor/common/recipes-phosphor/network/network.bb
+++ b/meta-phosphor/common/recipes-phosphor/network/network.bb
@@ -10,7 +10,7 @@ RDEPENDS_${PN} += "python-dbus python-pygobject"
 
 SRC_URI += "git://github.com/openbmc/phosphor-networkd"
 
-SRCREV = "448e8d839d37532d2667b9a38bb3aadb6c804e2e"
+SRCREV = "682512485947977a8d130a1cf9832b12583ea253"
 
 S = "${WORKDIR}/git"
 

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
@@ -13,7 +13,7 @@ TARGET_CPPFLAGS += "-std=c++11 -fpic"
 
 SRC_URI += "git://github.com/openbmc/phosphor-event"
 
-SRCREV = "127c8cf513ba9ed6bcc460fbea29b36eb8d23bac"
+SRCREV = "0396126c2d816529d57cee2b413727eb78f7cef3"
 
 RDEPENDS_${PN} += "libsystemd"
 DEPENDS += "systemd"

--- a/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
@@ -20,7 +20,7 @@ SRC_URI += "git://github.com/openbmc/skeleton"
 PACKAGECONFIG ??= "${@bb.utils.contains('MACHINE_FEATURES', 'openpower-pflash', 'openpower-pflash', '', d)}"
 PACKAGECONFIG[openpower-pflash] = ",,,pflash"
 
-SRCREV = "27ca44ad1a96f90d42dcb50183700e5ca5358642"
+SRCREV = "d3e6edc748f026dcd68d20306a1cfe0e26df22a9"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
Add release version id to inventory and IPMI interface
Add REST interface to query the type of network interface
Add event REST association suppot
Fix inventory data for CPU1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/251)
<!-- Reviewable:end -->
