### PR TITLE
VERSION_ID is not granular

### DIFF
--- a/meta-phosphor/common/recipes-core/os-release/os-release.bbappend
+++ b/meta-phosphor/common/recipes-core/os-release/os-release.bbappend
@@ -6,11 +6,11 @@ def run_git(d, cmd):
                 pass
 
 python() {
-        version_id = run_git(d, 'describe --abbrev=0')
+        version_id = run_git(d, 'describe --dirty')
         if version_id:
                 d.setVar('VERSION_ID', version_id)
 
-        build_id = run_git(d, 'describe --dirty')
+        build_id = run_git(d, 'describe --abbrev=0')
         if build_id:
                 d.setVar('BUILD_ID', build_id)
 }


### PR DESCRIPTION
Currently VERSION_ID is v0.6
Even when I am 30 commits past the tag.  I am swapping the code's BUILD/VERSION populator
to ensure we adhere to the reason why VERSION_ID exists in the first place... to know what
level of code you have on the system

Definition of what the VERSION_ID is for...
https://www.freedesktop.org/software/systemd/man/os-release.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/253)
<!-- Reviewable:end -->
