### PR TITLE
Add version_id support in to openbmc

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -19,7 +19,7 @@ RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = "2bcf128699eaff43f4bd4084ab4096d49d782b6b"
+SRCREV = "eee949f14d921d84497f41df84ab7ae45a0d830d"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "ipmid"


### PR DESCRIPTION
Adding https://github.com/openbmc/phosphor-host-ipmid/commit/176c96534484213dfb19d2ef5f70306b145a4fcf
to all the ipmi -I dbus mc info command to reflect what is seen via REST

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/254)
<!-- Reviewable:end -->
