### PR TITLE
meta-phosphor: Move to openbmc-20160505-1

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.4.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.4.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 LINUX_VERSION ?= "4.4"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20160329-2"
+SRCREV="openbmc-20160505-1"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
 - Update to 4.4.9 for security and bug fixes
 - Adds device tree and network phy for firestone support

Signed-off-by: Joel Stanley <joel@jms.id.au>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/255)
<!-- Reviewable:end -->
