### PR TITLE
meta-phosphor: Move to openbmc-20160511-1

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.4.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.4.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 LINUX_VERSION ?= "4.4"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20160505-1"
+SRCREV="openbmc-20160511-1"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
 - Enables network cable link detection
 - Adds support for VOUT sampling to the adm1275 driver

Fixes https://github.com/openbmc/linux/issues/71 and https://github.com/openbmc/linux/issues/61

Signed-off-by: Joel Stanley <joel@jms.id.au>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/270)
<!-- Reviewable:end -->
