### PR TITLE
Bump version for console, object manager, and event logs

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper.bb
+++ b/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper.bb
@@ -18,6 +18,6 @@ RDEPENDS_${PN} += " \
         "
 SRC_URI += "git://github.com/openbmc/phosphor-objmgr"
 
-SRCREV = "2abc4d068cec75aa3893af8197108d29ff6f1bb4"
+SRCREV = "f7aa902e465bfe1cf19b9079f1555633a88e7190"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-console/obmc-console.bb
@@ -14,7 +14,7 @@ SRC_URI += "file://${PN}.conf \
 	    file://obmc-console-ssh.socket \
 	    file://obmc-console-ssh@.service"
 
-SRCREV = "2eacda524e98c7964e542e01aabf82360cf60344"
+SRCREV = "bc1e893375e4887ef7676c5738779c4a2f5b1935"
 
 FILES_${PN} += "${systemd_unitdir}/system/obmc-console-ssh@.service \
 		${systemd_unitdir}/system/obmc-console-ssh.socket"

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/files/obmc-phosphor-event.service
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/files/obmc-phosphor-event.service
@@ -2,7 +2,7 @@
 Description=Phosphor OpenBMC event management daemon
 
 [Service]
-ExecStart=/usr/sbin/obmc-phosphor-eventd -s 200000
+ExecStart=/usr/sbin/obmc-phosphor-eventd -s 200000 -t 128
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
@@ -13,7 +13,7 @@ TARGET_CPPFLAGS += "-std=c++11 -fpic"
 
 SRC_URI += "git://github.com/openbmc/phosphor-event"
 
-SRCREV = "0396126c2d816529d57cee2b413727eb78f7cef3"
+SRCREV = "d8fbb0a07dc0c68b3f5d074bddca96eccaca14b4"
 
 RDEPENDS_${PN} += "libsystemd"
 DEPENDS += "systemd"


### PR DESCRIPTION
Updates for:
Console - Support for local tty mirroring
Object manager - BMC boot performance improvements
Event logs - Cap the number of event logs at 128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/279)
<!-- Reviewable:end -->
