### PR TITLE
Release openbmc-20160521-1

### DIFF
--- a/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.4.bb
+++ b/meta-phosphor/common/recipes-kernel/linux/linux-obmc_4.4.bb
@@ -10,7 +10,7 @@ SRC_URI = "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
 LINUX_VERSION ?= "4.4"
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"
 
-SRCREV="openbmc-20160518-1"
+SRCREV="openbmc-20160521-1"
 
 PV = "${LINUX_VERSION}+git${SRCPV}"
 


### PR DESCRIPTION
- Enable shmem in config, fixing qemu bootin
- Add latest version of Yi's OCC hwmon driver to support barreleye

Signed-off-by: Joel Stanley <joel@jms.id.au>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/294)
<!-- Reviewable:end -->
