### PR TITLE
Bump skeleton version

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
@@ -20,7 +20,7 @@ SRC_URI += "git://github.com/openbmc/skeleton"
 PACKAGECONFIG ??= "${@bb.utils.contains('MACHINE_FEATURES', 'openpower-pflash', 'openpower-pflash', '', d)}"
 PACKAGECONFIG[openpower-pflash] = ",,,pflash"
 
-SRCREV = "264009617c231447d6c8fc61264cf3c6ea7f49d5"
+SRCREV = "f55a1cda5898ed5cb97ada7a0ed4bf68f4b4977d"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
Fix OCC hardcoded sensor
Add adm1278 sensors
Fix preserving u-boot env variables during BMC updates
Add gpio Q7 handling

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/301)
<!-- Reviewable:end -->
