### PR TITLE
Bump IPMI, networkd, REST, and skeleton versions

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
@@ -18,7 +18,7 @@ TARGET_CFLAGS += " -fpic -std=gnu++14"
 
 SRC_URI += "git://github.com/openbmc/ipmi-fru-parser"
 
-SRCREV = "a14239a201443222906864273449a39cfa84118e"
+SRCREV = "9702c89eba59fbf2c665a693317ba0a4f4843872"
 
 FILES_${PN} += "${libdir}/host-ipmid/*.so"
 FILES_${PN}-dbg += "${libdir}/host-ipmid/.debug"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-oem.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-oem.bb
@@ -19,7 +19,7 @@ RDEPENDS_${PN} += "libsystemd"
 
 SRC_URI += "git://github.com/openbmc/openpower-host-ipmi-oem"
 
-SRCREV = "345932324ce63d42fd88e762cb539c864167b008"
+SRCREV = "ca99efb722ff757707e27f91ba6af293d7e09753"
 
 FILES_${PN} += "${libdir}/host-ipmid/*.so"
 FILES_${PN}-dbg += "${libdir}/host-ipmid/.debug"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -19,7 +19,7 @@ RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = "eee949f14d921d84497f41df84ab7ae45a0d830d"
+SRCREV = "c6a5b9dc33a8faa8bb8b907e186325b928978510"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "ipmid"

--- a/meta-phosphor/common/recipes-phosphor/network/network.bb
+++ b/meta-phosphor/common/recipes-phosphor/network/network.bb
@@ -10,7 +10,7 @@ RDEPENDS_${PN} += "python-dbus python-pygobject"
 
 SRC_URI += "git://github.com/openbmc/phosphor-networkd"
 
-SRCREV = "682512485947977a8d130a1cf9832b12583ea253"
+SRCREV = "fbf7d68e78684739ff860f20f6cbdd0932003912"
 
 S = "${WORKDIR}/git"
 

--- a/meta-phosphor/common/recipes-phosphor/rest-dbus/rest-dbus.bb
+++ b/meta-phosphor/common/recipes-phosphor/rest-dbus/rest-dbus.bb
@@ -21,6 +21,6 @@ SRC_URI += " \
         file://rest-dbus.service \
         "
 
-SRCREV = "c693ba1126dcb493058d4ebeb4604b71e3bb3f08"
+SRCREV = "64077101d9f2b6e51c897db82ffc0a399a34d15b"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
@@ -20,7 +20,7 @@ SRC_URI += "git://github.com/openbmc/skeleton"
 PACKAGECONFIG ??= "${@bb.utils.contains('MACHINE_FEATURES', 'openpower-pflash', 'openpower-pflash', '', d)}"
 PACKAGECONFIG[openpower-pflash] = ",,,pflash"
 
-SRCREV = "264009617c231447d6c8fc61264cf3c6ea7f49d5"
+SRCREV = "2f9ee83356fba3f6f843bf2584f3e7e95763ec98"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
Pick up:
Fix FRU VPD error messages
Add REST interface to update BMC via local file
Add Barreleye motherboard VPD to the inventory
Handle parallel IPMI SEL reservation requests
Add support to stream the journald log to a remote syslog

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/302)
<!-- Reviewable:end -->
