### PR TITLE
Fix i2c-tools SRCURI syntax

### DIFF
--- a/meta-phosphor/common/recipes-devtools/i2c-tools/i2c-tools_%.bbappend
+++ b/meta-phosphor/common/recipes-devtools/i2c-tools/i2c-tools_%.bbappend
@@ -1,4 +1,5 @@
+# Prefer the Yocto mirror over the direct lm-sensors download.
 SRC_URI_remove = "http://dl.lm-sensors.org/i2c-tools/releases/${BP}.tar.bz2"
-SRC_URI_prepend = "http://downloads.yoctoproject.org/mirror/sources/${BP}.tar.bz2"
+SRC_URI =+ "http://downloads.yoctoproject.org/mirror/sources/${BP}.tar.bz2"
 
 RDEPENDS_${PN}_remove = "${PN}-misc"


### PR DESCRIPTION
Override syntax (FOO_append, FOO_prepend) doesn't insert spaces to
separate the append from the original value.  This caused the two URIs
to be incorrectly merged into one and caused a download failure.  It
happens that the fallback in that case is to use the Yocto mirror so it
kept working other than emitting a warning.  Using =+ prepend syntax
correctly adds the separating space.

Signed-off-by: Rick Altherr <raltherr@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/305)
<!-- Reviewable:end -->
