### PR TITLE
Pin host-ipmi-hw-example to a specific Git SRCREV

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmi-hw-example.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmi-hw-example.bb
@@ -11,7 +11,7 @@ inherit obmc-phosphor-host-ipmi-hw
 
 S = "${WORKDIR}/git"
 SRC_URI += "git://github.com/openbmc/skeleton.git;subpath=bin;destsuffix=git"
-SRCREV="${AUTOREV}"
+SRCREV="2f9ee83356fba3f6f843bf2584f3e7e95763ec98"
 
 SCRIPT_NAME = "ipmi_debug.py"
 INSTALL_NAME = "host-ipmi-hw"


### PR DESCRIPTION
AUTOREV assumes you can reach the remote repository to lookup the most
recent commit.  When setting up a hermetic build, that will fail even
though a local mirror tarball exists.  Pinning the recipe to a specific
revision skips the lookup and just checks out the specified commit from
the local mirror tarball.

Change-Id: I05cfa67dfcd321ff28a93453df5ce1c82666e6c1
Signed-off-by: Rick Altherr <raltherr@google.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/308)
<!-- Reviewable:end -->
