### PR TITLE
Add shared library versioning for host-ipmid-fru

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
@@ -18,10 +18,11 @@ TARGET_CFLAGS += " -fpic -std=gnu++14"
 
 SRC_URI += "git://github.com/openbmc/ipmi-fru-parser"
 
-SRCREV = "2f5a3cfd2412c7e10d128a856ad2c37c8a1b4a10"
+SRCREV = "bf9385f56f715426ff2ac3a1d77af6b6d1575fe1"
 
-FILES_${PN} += "${libdir}/host-ipmid/*.so"
-FILES_${PN}-dbg += "${libdir}/host-ipmid/.debug"
+FILES_SOLIBSDEV += "${libdir}/host-ipmid/lib*${SOLIBSDEV}"
+FILES_${PN} += "${libdir}/host-ipmid/lib*${SOLIBS}"
+FILES_${PN}-dbg += "${libdir}/host-ipmid/.debug/lib*${SOLIBS}"
 
 S = "${WORKDIR}/git"
 

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
@@ -7,10 +7,10 @@ RRECOMMENDS_${PN} = "virtual/obmc-phosphor-host-ipmi-hw"
 
 inherit obmc-phosphor-license
 
-DEPENDS += "systemd    \
-		 	host-ipmid \
-		 	"
-
+DEPENDS += " \
+        systemd \
+        host-ipmid \
+        "
 
 RDEPENDS_${PN} += "libsystemd"
 
@@ -26,9 +26,5 @@ FILES_${PN}-dbg += "${libdir}/host-ipmid/.debug"
 S = "${WORKDIR}/git"
 
 do_install() {
-	oe_runmake install DESTDIR=${D} LIBDIR=${libdir} BINDIR=${sbindir}
+        oe_runmake install DESTDIR=${D} LIBDIR=${libdir} BINDIR=${sbindir}
 }
-
-
-#        install -m 0755 -d ${D}${libdir}/host-ipmid
-#        install -m 0755 ${S}/*.so ${D}${libdir}/host-ipmid/


### PR DESCRIPTION
OE packaging works best with libraries with proper versioning.  This patchest picks up a change in host-ipmid-fru that enables versioning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/326)
<!-- Reviewable:end -->
