### PR TITLE
Bump pyphosphor, host-ipmid versions

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper/obmc-mapper.service
+++ b/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper/obmc-mapper.service
@@ -5,7 +5,7 @@ Description=Phosphor OpenBMC DBus service management daemon
 Restart=always
 Type=dbus
 ExecStart=/usr/sbin/phosphor-mapper
-BusName=org.openbmc.objectmapper
+BusName=org.openbmc.ObjectMapper
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -19,7 +19,7 @@ RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = "93a753f01b464e120c88a28c463a909a952585bb"
+SRCREV = "092360e55605c205aedd2ab40044c42e64b7d38c"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "ipmid"

--- a/meta-phosphor/common/recipes-phosphor/skeleton/pyphosphor.bb
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/pyphosphor.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Phosphor python library"
 DESCRIPTION = "Phosphor python library."
-HOMEPAGE = "http://github.com/openbmc/pyobmc"
+HOMEPAGE = "http://github.com/openbmc/pyphosphor"
 PR = "r1"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
@@ -10,6 +10,6 @@ inherit setuptools
 
 SRC_URI += "git://github.com/openbmc/pyphosphor"
 
-SRCREV = "362fb80c081e114236cc5d29b166f45fd4539041"
+SRCREV = "93aed45f230befa01c947173a908b120cfbe7017"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This picks up a couple fixes that addresses non-standard DBUS naming
conventions.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/369)
<!-- Reviewable:end -->
