### PR TITLE
Add build time dependencies to python for skeleton

### DIFF
--- a/meta-phosphor/classes/config-in-skeleton.bbclass
+++ b/meta-phosphor/classes/config-in-skeleton.bbclass
@@ -3,7 +3,9 @@
 
 inherit allarch
 inherit setuptools
+inherit pythonnative
 
+DEPENDS += "python"
 SRC_URI += "git://github.com/openbmc/skeleton;subpath=configs"
 S = "${WORKDIR}/configs"
 

--- a/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
@@ -16,7 +16,7 @@ inherit python-dir
 
 VIRTUAL-RUNTIME_skeleton_workbook ?= ""
 
-DEPENDS += "glib-2.0 systemd"
+DEPENDS += "glib-2.0 systemd python"
 RDEPENDS_${PN} += "python-subprocess python-compression libsystemd ${VIRTUAL-RUNTIME_skeleton_workbook}"
 SRC_URI += "git://github.com/openbmc/skeleton"
 


### PR DESCRIPTION
Skeleton now invokes python setuptools to install its python
applications in a top level makefile, so a build time dependency
on native-python is required.

It should be noted that skeleton invoking python from make is
an interim thing until its python applications get their own
repository.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/371)
<!-- Reviewable:end -->
