### PR TITLE
Remove rest-dbus from Barreleye

### DIFF
--- a/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/conf/local.conf.sample
+++ b/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/conf/local.conf.sample
@@ -243,3 +243,7 @@ INHERIT += "extrausers"
 EXTRA_USERS_PARAMS = " \
   usermod -p '\$1\$UGMqyqdG\$FZiylVFmRRfl9Z0Ue8G7e/' root; \
   "
+
+# Package exclusions - Exclude packages included by default in the common image
+IMAGE_INSTALL_remove = "packagegroup-obmc-phosphor-apps-extrasdev"
+

--- a/meta-phosphor/classes/obmc-phosphor-image.bbclass
+++ b/meta-phosphor/classes/obmc-phosphor-image.bbclass
@@ -38,6 +38,7 @@ IMAGE_FEATURES += " \
 
 CORE_IMAGE_EXTRA_INSTALL_append = " bash \
         packagegroup-obmc-phosphor-apps-extras \
+        packagegroup-obmc-phosphor-apps-extrasdev \
         i2c-tools \
         screen \
         inarp \

--- a/meta-phosphor/common/recipes-phosphor/packagegroups/packagegroup-obmc-phosphor-apps.bb
+++ b/meta-phosphor/common/recipes-phosphor/packagegroups/packagegroup-obmc-phosphor-apps.bb
@@ -13,6 +13,7 @@ VIRTUAL-RUNTIME_obmc-phosphor-flash-ctl ?= "virtual/obmc-phosphor-flash-ctl"
 PROVIDES = "${PACKAGES}"
 PACKAGES = " \
         packagegroup-obmc-phosphor-apps-extras \
+        packagegroup-obmc-phosphor-apps-extrasdev \
         ${@mf_enabled("obmc-phosphor-fan-mgmt", "packagegroup-obmc-phosphor-apps-fan-mgmt", d)} \
         ${@mf_enabled("obmc-phosphor-chassis-mgmt", "packagegroup-obmc-phosphor-apps-chassis-mgmt", d)} \
         ${@mf_enabled("obmc-phosphor-sensor-mgmt", "packagegroup-obmc-phosphor-apps-sensor-mgmt", d)} \
@@ -25,9 +26,13 @@ PACKAGES = " \
 
 SUMMARY_packagegroup-obmc-phosphor-apps-extras = "Extra features"
 RDEPENDS_packagegroup-obmc-phosphor-apps-extras = " \
-        rest-dbus \
 	obmc-rest \
         host-ipmid \
+        "
+
+SUMMARY_packagegroup-obmc-phosphor-apps-extrasdev = "Development features"
+RDEPENDS_packagegroup-obmc-phosphor-apps-extrasdev = " \
+        rest-dbus \
         "
 
 SUMMARY_packagegroup-obmc-phosphor-apps-fan-mgmt = "Fan management support"


### PR DESCRIPTION
Remove the rest-dbus development debug package from Barreleye now that Barreleye is going into production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/379)
<!-- Reviewable:end -->
