### PR TITLE
Bump versions for skeleton, rest, inarp, event

### DIFF
--- a/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/recipes-phosphor/workbook/palmetto-config.bb
+++ b/meta-openbmc-machines/meta-openpower/meta-ibm/meta-palmetto/recipes-phosphor/workbook/palmetto-config.bb
@@ -3,6 +3,6 @@ DESCRIPTION = "Board wiring information for the Palmetto system."
 HOMEPAGE = "http://github.com/openbmc/skeleton"
 PR = "r1"
 
-SRCREV = "5213a991a5a3bd107636f1b2cc3bbca560843462"
+SRCREV = "cbe32133dadf0945357e2bec67aa7a86ae9f0295"
 inherit config-in-skeleton
 inherit obmc-phosphor-license

--- a/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/recipes-phosphor/workbook/barreleye-config.bb
+++ b/meta-openbmc-machines/meta-openpower/meta-rackspace/meta-barreleye/recipes-phosphor/workbook/barreleye-config.bb
@@ -3,6 +3,6 @@ DESCRIPTION = "Board wiring information for the Barreleye system."
 HOMEPAGE = "http://github.com/openbmc/skeleton"
 PR = "r1"
 
-SRCREV = "5213a991a5a3bd107636f1b2cc3bbca560843462"
+SRCREV = "cbe32133dadf0945357e2bec67aa7a86ae9f0295"
 inherit config-in-skeleton
 inherit obmc-phosphor-license

--- a/meta-phosphor/common/recipes-phosphor/dbus/obmc-rest.bb
+++ b/meta-phosphor/common/recipes-phosphor/dbus/obmc-rest.bb
@@ -17,6 +17,7 @@ RDEPENDS_${PN} += " \
         python-rocket \
         python-bottle \
         python-spwd \
+        python-netserver \
         pyphosphor \
         "
 SRC_URI += "git://github.com/openbmc/phosphor-rest-server"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid-fru.bb
@@ -18,7 +18,7 @@ TARGET_CFLAGS += " -fpic -std=gnu++14"
 
 SRC_URI += "git://github.com/openbmc/ipmi-fru-parser"
 
-SRCREV = "bf9385f56f715426ff2ac3a1d77af6b6d1575fe1"
+SRCREV = "a26ed7375261ebcfffa68cf478bcb8f2204c6c92"
 
 FILES_SOLIBSDEV += "${libdir}/host-ipmid/lib*${SOLIBSDEV}"
 FILES_${PN} += "${libdir}/host-ipmid/lib*${SOLIBS}"

--- a/meta-phosphor/common/recipes-phosphor/inarp/inarp.bb
+++ b/meta-phosphor/common/recipes-phosphor/inarp/inarp.bb
@@ -11,7 +11,7 @@ TARGET_CFLAGS   += "-fpic -O2"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/inarp"
 
-SRCREV = "e3f27cf06cc2ca93ae9746ba705a0d9fc307cec2"
+SRCREV = "04d1f97f2e6e471d63c7d56dce7bd8472eb8fbfb"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "inarp"

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-event/obmc-phosphor-event.bb
@@ -13,7 +13,7 @@ TARGET_CPPFLAGS += "-std=c++11 -fpic"
 
 SRC_URI += "git://github.com/openbmc/phosphor-event"
 
-SRCREV = "d8fbb0a07dc0c68b3f5d074bddca96eccaca14b4"
+SRCREV = "d4a7217f42f065396e509b94940319261682f144"
 
 RDEPENDS_${PN} += "libsystemd"
 DEPENDS += "systemd"

--- a/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
@@ -17,7 +17,7 @@ inherit python-dir
 VIRTUAL-RUNTIME_skeleton_workbook ?= ""
 
 DEPENDS += "glib-2.0 systemd python"
-RDEPENDS_${PN} += "python-subprocess python-compression libsystemd ${VIRTUAL-RUNTIME_skeleton_workbook}"
+RDEPENDS_${PN} += "python-json python-subprocess python-compression libsystemd ${VIRTUAL-RUNTIME_skeleton_workbook}"
 SRC_URI += "git://github.com/openbmc/skeleton"
 
 FILES_${PN} += "${PYTHON_SITEPACKAGES_DIR}/*"
@@ -26,7 +26,7 @@ FILES_${PN} += "${PYTHON_SITEPACKAGES_DIR}/*"
 PACKAGECONFIG ??= "${@bb.utils.contains('MACHINE_FEATURES', 'openpower-pflash', 'openpower-pflash', '', d)}"
 PACKAGECONFIG[openpower-pflash] = ",,,pflash"
 
-SRCREV = "40187443840d0e419c13391b2091fda29d63dea4"
+SRCREV = "cbe32133dadf0945357e2bec67aa7a86ae9f0295"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
Bump recipe versions and add python dependencies.
The rest-dbus recipe was adding pythong packages needed
by other processes, so when rest-dbus was removed from the
Barreleye image, these processes (skeleton and obmc-rest)
would fail, so adding the python dependencies to those recipes.

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/393)
<!-- Reviewable:end -->
