### PR TITLE
Update recipe and service file for phosphor-networkd

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/network/network.bb
+++ b/meta-phosphor/common/recipes-phosphor/network/network.bb
@@ -5,17 +5,21 @@ PR = "r1"
 
 inherit obmc-phosphor-license
 inherit obmc-phosphor-systemd
+inherit obmc-phosphor-sdbus-service
+
+SYSTEMD_SERVICE_${PN} += "network.service network-update-dns.service"
 
 RDEPENDS_${PN} += "python-dbus python-pygobject"
 
 SRC_URI += "git://github.com/openbmc/phosphor-networkd"
 
-SRCREV = "fbf7d68e78684739ff860f20f6cbdd0932003912"
+SRCREV = "c69c3d30fd7d5fd04ba990788b6d75b19f275fc8"
 
 S = "${WORKDIR}/git"
 
 do_install() {
         install -d ${D}/${sbindir}
         install ${S}/netman.py ${D}/${sbindir}
+        install ${S}/netman_watch_dns ${D}/${sbindir}
 }
 

--- a/meta-phosphor/common/recipes-phosphor/network/network/network-update-dns.service
+++ b/meta-phosphor/common/recipes-phosphor/network/network/network-update-dns.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=DNS update handler
+Requires=network.service
+After=network.service
+
+[Service]
+ExecStart=/usr/sbin/netman_watch_dns /run/systemd/netif/state
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Commit c69c3d3 for phosphor-netword introduced DNS support.
This change will update the bitbake file to point to correct commit
and also creates the service file to start DNS updater.

Fixes openbmc/openbmc#134

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/394)
<!-- Reviewable:end -->
