### PR TITLE
Package whitelist.conf in obmc-phosphor-image

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -17,7 +17,10 @@ TARGET_CFLAGS   += "-fpic"
 RDEPENDS_${PN} += "clear-once"
 RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
-SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
+SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid \
+            file://host-ipmid-whitelist.conf \
+            file://ipmi-fru-parser-whitelist.conf \
+            file://openpower-host-ipmi-oem-whitelist.conf"
 
 SRCREV = "b7bcda57ee39616e8937194d281e2476e6ea8df2"
 
@@ -30,4 +33,17 @@ do_install() {
 
         install -m 0755 -d ${D}${includedir}/host-ipmid
         install -m 0644 ${S}/ipmid-api.h ${D}${includedir}/host-ipmid/
+}
+
+def find_cfgs(d):
+    sources=src_patches(d, True)
+    sources_list=[]
+    for s in sources:
+        if s.endswith('.conf'):
+            sources_list.append(s)
+
+    return sources_list
+
+do_configure () {
+        ${S}/generate_whitelist.sh ${@" ".join(find_cfgs(d))}  > ipmiwhitelist.C
 }

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bbappend
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}/files:"

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid/files/host-ipmid-whitelist.conf
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid/files/host-ipmid-whitelist.conf
@@ -1,0 +1,24 @@
+#<NetFn>:<Command>
+0x00:0x02	//<Chassis>:<Chassis Control>
+0x00:0x08	//<Chassis>:<Set System Boot Options>
+0x00:0x09	//<Chassis>:<Get System Boot Options>
+0x04:0x2D	//<Sensor/Event>:<Get Sensor Reading>
+0x04:0x2F	//<Sensor/Event>:<Get Sensor Type>
+0x04:0x30	//<Sensor/Event>:<Set Sensor Reading and Event Status>
+0x06:0x01	//<App>:<Get Device ID>
+0x06:0x08	//<App>:<Get Device GUID>
+0x06:0x22	//<App>:<Reset Watchdog Timer>
+0x06:0x24	//<App>:<Set Watchdog Timer>
+0x06:0x2E	//<App>:<Set BMC Global Enables>
+0x06:0x31	//<App>:<Get Message Flags>
+0x06:0x35	//<App>:<Read Event Message Buffer>
+0x06:0x36	//<App>:<Get BT Interface Capabilities>
+0x06:0x42	//<App>:<Get Channel Info Command>
+0x0A:0x40	//<Storage>:<Get SEL Info>
+0x0A:0x42	//<Storage>:<Reserve SEL>
+0x0A:0x44	//<Storage>:<Add SEL Entry>
+0x0A:0x48	//<Storage>:<Get SEL Time>
+0x0A:0x49	//<Storage>:<Set SEL Time>
+0x0C:0x02	//<Transport>:<Get LAN Configuration Parameters>
+0x2C:0x00	//<Group Extension>:<Group Extension Command>
+0x2C:0x03	//<Group Extension>:<Get Power Limit>

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid/files/ipmi-fru-parser-whitelist.conf
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid/files/ipmi-fru-parser-whitelist.conf
@@ -1,0 +1,2 @@
+#<NetFn>:<Command>
+0x0A:0x12	//<Storage>:<Write FRU Data>

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid/files/openpower-host-ipmi-oem-whitelist.conf
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid/files/openpower-host-ipmi-oem-whitelist.conf
@@ -1,0 +1,2 @@
+#<NetFn>:<Command>
+0x32:0xF0	//<OpenPower OEM>:<Add Partial eSEL command>


### PR DESCRIPTION
IPMI whitelisted commands are added in whitelist.conf
which would be consumed by ipmid daemon. Only whitelisted
IPMI commands are executed in restricted mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/395)
<!-- Reviewable:end -->
