### PR TITLE
Remove unnecessary skeleton dependencies

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/network/network/network.service
+++ b/meta-phosphor/common/recipes-phosphor/network/network/network.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Network DBUS object
-Requires=skeleton.service
-After=skeleton.service
 
 [Service]
 ExecStart=/usr/sbin/netman.py

--- a/meta-phosphor/common/recipes-phosphor/settings/settings/settings.service
+++ b/meta-phosphor/common/recipes-phosphor/settings/settings/settings.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=Settings DBUS Object
-Requires=skeleton.service
-After=skeleton.service
 
 [Service]
 ExecStart=/usr/sbin/settings_manager.py


### PR DESCRIPTION
The network and settings daemons had unnecessary startup dependencies
on the skeleton service.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/403)
<!-- Reviewable:end -->
