### PR TITLE
Bump skeleton, obmc-mapper versions

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper.bb
+++ b/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper.bb
@@ -18,6 +18,6 @@ RDEPENDS_${PN} += " \
         "
 SRC_URI += "git://github.com/openbmc/phosphor-objmgr"
 
-SRCREV = "0bdc22a259720ee3a7ca78ee3aa07ab83bb39743"
+SRCREV = "067db7287a647789e7d5d5dbccc514c5c835a944"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper/obmc-mapper.service
+++ b/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper/obmc-mapper.service
@@ -6,6 +6,7 @@ Restart=always
 Type=dbus
 ExecStart=/usr/sbin/phosphor-mapper
 BusName=org.openbmc.ObjectMapper
+TimeoutStartSec=300
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
@@ -18,7 +18,7 @@ VIRTUAL-RUNTIME_skeleton_workbook ?= ""
 
 DEPENDS += "glib-2.0 systemd python"
 RDEPENDS_${PN} += "python-json python-subprocess python-compression libsystemd ${VIRTUAL-RUNTIME_skeleton_workbook}"
-SRC_URI += "git://github.com/openbmc/skeleton"
+SRC_URI += "git://github.com//skeleton"
 
 FILES_${PN} += "${PYTHON_SITEPACKAGES_DIR}/*"
 
@@ -26,7 +26,7 @@ FILES_${PN} += "${PYTHON_SITEPACKAGES_DIR}/*"
 PACKAGECONFIG ??= "${@bb.utils.contains('MACHINE_FEATURES', 'openpower-pflash', 'openpower-pflash', '', d)}"
 PACKAGECONFIG[openpower-pflash] = ",,,pflash"
 
-SRCREV = "cbe32133dadf0945357e2bec67aa7a86ae9f0295"
+SRCREV = "fa8f6166a05410472e8a3ef6a2f2e3b9b5f8d8e4"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
This picks up a couple skeleton bug fixes and performance improvements
for the obmc-mapper application.
Extend the mapper service startup timeout.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/413)
<!-- Reviewable:end -->
