### PR TITLE
Bump versions for skeleton, IPMI, obmc-mapper

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper.bb
+++ b/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper.bb
@@ -18,6 +18,6 @@ RDEPENDS_${PN} += " \
         "
 SRC_URI += "git://github.com/openbmc/phosphor-objmgr"
 
-SRCREV = "0bdc22a259720ee3a7ca78ee3aa07ab83bb39743"
+SRCREV = "067db7287a647789e7d5d5dbccc514c5c835a944"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper/obmc-mapper.service
+++ b/meta-phosphor/common/recipes-phosphor/dbus/obmc-mapper/obmc-mapper.service
@@ -6,6 +6,7 @@ Restart=always
 Type=dbus
 ExecStart=/usr/sbin/phosphor-mapper
 BusName=org.openbmc.ObjectMapper
+TimeoutStartSec=300
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
+++ b/meta-phosphor/common/recipes-phosphor/host-ipmid/host-ipmid.bb
@@ -19,7 +19,7 @@ RDEPENDS_${PN} += "settings"
 RDEPENDS_${PN} += "network"
 SRC_URI += "git://github.com/openbmc/phosphor-host-ipmid"
 
-SRCREV = "092360e55605c205aedd2ab40044c42e64b7d38c"
+SRCREV = "b7bcda57ee39616e8937194d281e2476e6ea8df2"
 
 S = "${WORKDIR}/git"
 INSTALL_NAME = "ipmid"

--- a/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
+++ b/meta-phosphor/common/recipes-phosphor/skeleton/skeleton.bb
@@ -26,7 +26,7 @@ FILES_${PN} += "${PYTHON_SITEPACKAGES_DIR}/*"
 PACKAGECONFIG ??= "${@bb.utils.contains('MACHINE_FEATURES', 'openpower-pflash', 'openpower-pflash', '', d)}"
 PACKAGECONFIG[openpower-pflash] = ",,,pflash"
 
-SRCREV = "57f67f07c8d5c8bc73dc0cd3440c8a44fafa6941"
+SRCREV = "fa8f6166a05410472e8a3ef6a2f2e3b9b5f8d8e4"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
Pick changes for:
Encoding firmware version in BCD format
Handle floating point sensor values
Performance improvements
Extend the mapper service startup timeout

Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/415)
<!-- Reviewable:end -->
