### PR TITLE
rpm: explicitly disable tomcrypt

### DIFF
--- a/yocto-poky/meta/recipes-devtools/rpm/rpm_5.4.16.bb
+++ b/yocto-poky/meta/recipes-devtools/rpm/rpm_5.4.16.bb
@@ -328,6 +328,7 @@ EXTRA_OECONF += "--verbose \
 		--without-ruby \
 		--without-squirrel \
 		--without-sasl2 \
+		--without-tomcrypt \
 		--with-build-extlibdep \
 		--with-build-maxextlibdep \
 		--without-valgrind \


### PR DESCRIPTION
Configure autodetects libtomcrypt, but then it adds libtommath to
$LIBS and fails to link subsequent tests if it's unavailable.

| checking for pcre.h... yes
| checking for pcre_compile in -lpcre... no
| checking whether to build with PCRE library... no
| ++ executing failure action
| configure: error: unable to find usable PCRE library

(From OE-Core rev: 54665fb9e27ba1b0e4eddaf170303d4f2db66fae)

Signed-off-by: Andreas Oberritter <obi@opendreambox.org>
Signed-off-by: Ross Burton <ross.burton@intel.com>
Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/424)
<!-- Reviewable:end -->
