### PR TITLE
Force OLDEST_KERNEL to 4.4.0

### DIFF
--- a/meta-phosphor/conf/distro/openbmc-phosphor.conf
+++ b/meta-phosphor/conf/distro/openbmc-phosphor.conf
@@ -5,6 +5,7 @@ DISTRO_NAME = "Phosphor OpenBMC (Phosphor OpenBMC Project Reference Distro)"
 DISTRO_VERSION = "0.1.0"
 TARGET_VENDOR="-openbmc"
 
+OLDEST_KERNEL = "4.4.0"
 GCCVERSION ?= "4.9.3"
 IMAGE_FSTYPES += "cpio.gz"
 IMAGE_FSTYPES += "squashfs-xz"


### PR DESCRIPTION
This is the oldest kernel currently used by openbmc, so there is no
point in compiling glibc support older kernels.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/425)
<!-- Reviewable:end -->
