### PR TITLE
meta-witherspoon: Bump kernel version

### DIFF
--- a/meta-openbmc-machines/meta-openpower/meta-ibm/meta-witherspoon/recipes-kernel/linux/linux-obmc_4.7.bb
+++ b/meta-openbmc-machines/meta-openpower/meta-ibm/meta-witherspoon/recipes-kernel/linux/linux-obmc_4.7.bb
@@ -1,6 +1,6 @@
 KBRANCH ?= "dev-4.7"
 LINUX_VERSION ?= "4.7"
-SRCREV="05543e532c78185ba82057415f96d13e5f500072"
+SRCREV="b172f8b68d85450a12d4348ee4a006ef8844fe95"
 KSRC = "git://github.com/shenki/linux;protocol=git;branch=${KBRANCH}"
 
 require common/recipes-kernel/linux/linux-obmc.inc


### PR DESCRIPTION
This enables all of the i2c buses that are present in the hardware.

Signed-off-by: Joel Stanley <joel@jms.id.au>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/456)
<!-- Reviewable:end -->
