### PR TITLE
Add some missing dependencies to obmc-flash-bmc

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-flash/obmc-flash-bmc.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-flash/obmc-flash-bmc.bb
@@ -9,6 +9,8 @@ RDEPENDS_${PN} += "\
         python-compression \
         python-shell \
         python-pygobject \
+        python-subprocess \
+        python-io \
         pyphosphor \
         "
 


### PR DESCRIPTION
A couple new python modules were added to bmc_update.py.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/459)
<!-- Reviewable:end -->
