### PR TITLE
Remove extra busses from python and sdbus examples

### DIFF
--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/files/obmc-phosphor-example-pydbus.py
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/files/obmc-phosphor-example-pydbus.py
@@ -86,8 +86,7 @@ if __name__ == '__main__':
 	bus = dbus.SystemBus()
 
 	services = []
-	services.append(dbus.service.BusName(SERVICE_PREFIX + '.PythonService0', bus))
-	services.append(dbus.service.BusName(SERVICE_PREFIX + '.PythonService1', bus))
+	services.append(dbus.service.BusName(SERVICE_PREFIX + '.PythonService', bus))
 
 	objs = []
 	objs.append(SampleObjectOne(bus, BASE_OBJ_PATH + 'path0/PythonObj'))

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/files/org.openbmc.examples.PythonService.conf
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/files/org.openbmc.examples.PythonService.conf
@@ -2,7 +2,7 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
   <policy user="root">
-    <allow own="org.openbmc.examples.PythonService1"/>
-    <allow send_destination="org.openbmc.examples.PythonService1"/>
+    <allow own="org.openbmc.examples.PythonService"/>
+    <allow send_destination="org.openbmc.examples.PythonService"/>
   </policy>
 </busconfig>

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/files/org.openbmc.examples.PythonService0.conf
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/files/org.openbmc.examples.PythonService0.conf
@@ -1,8 +1,0 @@
-<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
- "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
-<busconfig>
-  <policy user="root">
-    <allow own="org.openbmc.examples.PythonService0"/>
-    <allow send_destination="org.openbmc.examples.PythonService0"/>
-  </policy>
-</busconfig>

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/files/pyclient-sample.py
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/files/pyclient-sample.py
@@ -36,9 +36,9 @@ if __name__ == '__main__':
 
 	bus = dbus.SystemBus()
 
-	obj0 = bus.get_object(SERVICE_PREFIX + '.PythonService0',
+	obj0 = bus.get_object(SERVICE_PREFIX + '.PythonService',
 		                      BASE_OBJ_PATH + 'path0/PythonObj')
-	obj1 = bus.get_object(SERVICE_PREFIX + '.PythonService1',
+	obj1 = bus.get_object(SERVICE_PREFIX + '.PythonService',
 		                      BASE_OBJ_PATH + 'path1/PythonObj')
 	echo0= dbus.Interface(obj0,
 		    dbus_interface=IFACE_PREFIX + '.Echo')

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/obmc-phosphor-example-pydbus.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-pydbus/obmc-phosphor-example-pydbus.bb
@@ -3,8 +3,7 @@ DESCRIPTION = "Phosphor OpenBMC QEMU BSP example implementation."
 PR = "r1"
 
 DBUS_SERVICES = " \
-        org.openbmc.examples.PythonService0 \
-        org.openbmc.examples.PythonService1 \
+        org.openbmc.examples.PythonService \
         "
 
 inherit obmc-phosphor-pydbus-service

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-sdbus/files/obmc-phosphor-example-sdbus.c
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-sdbus/files/obmc-phosphor-example-sdbus.c
@@ -79,13 +79,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	/* Take a well-known service name so that clients can find us */
-	r = sd_bus_request_name(bus, "org.openbmc.examples.SDBusService0", 0);
-	if (r < 0) {
-		fprintf(stderr, "Failed to acquire service name: %s\n", strerror(-r));
-		goto finish;
-	}
-
-	r = sd_bus_request_name(bus, "org.openbmc.examples.SDBusService1", 0);
+	r = sd_bus_request_name(bus, "org.openbmc.examples.SDBusService", 0);
 	if (r < 0) {
 		fprintf(stderr, "Failed to acquire service name: %s\n", strerror(-r));
 		goto finish;

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-sdbus/files/org.openbmc.examples.SDBusService.conf
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-sdbus/files/org.openbmc.examples.SDBusService.conf
@@ -2,7 +2,7 @@
  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
   <policy user="root">
-    <allow own="org.openbmc.examples.SDBusService0"/>
-    <allow send_destination="org.openbmc.examples.SDBusService0"/>
+    <allow own="org.openbmc.examples.SDBusService"/>
+    <allow send_destination="org.openbmc.examples.SDBusService"/>
   </policy>
 </busconfig>

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-sdbus/files/org.openbmc.examples.SDBusService1.conf
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-sdbus/files/org.openbmc.examples.SDBusService1.conf
@@ -1,8 +1,0 @@
-<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
- "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
-<busconfig>
-  <policy user="root">
-    <allow own="org.openbmc.examples.SDBusService1"/>
-    <allow send_destination="org.openbmc.examples.SDBusService1"/>
-  </policy>
-</busconfig>

--- a/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-sdbus/obmc-phosphor-example-sdbus.bb
+++ b/meta-phosphor/common/recipes-phosphor/obmc-phosphor-example-sdbus/obmc-phosphor-example-sdbus.bb
@@ -3,8 +3,7 @@ DESCRIPTION = "Phosphor OpenBMC QEMU BSP example implementation."
 PR = "r1"
 
 DBUS_SERVICES = " \
-        org.openbmc.examples.SDBusService0 \
-        org.openbmc.examples.SDBusService1 \
+        org.openbmc.examples.SDBusService \
         "
 
 S = "${WORKDIR}"


### PR DESCRIPTION
I can't think of any use cases for this.  Removing to make things less confusing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/461)
<!-- Reviewable:end -->
