### PR TITLE
systemd: Add OpenBMC standby target

### DIFF
--- a/meta-phosphor/common/recipes-core/systemd/systemd/obmc-standby.target
+++ b/meta-phosphor/common/recipes-core/systemd/systemd/obmc-standby.target
@@ -1,0 +1,2 @@
+[Unit]
+Description=OpenBMC System

--- a/meta-phosphor/common/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-phosphor/common/recipes-core/systemd/systemd_%.bbappend
@@ -2,11 +2,16 @@ PACKAGECONFIG_append = " networkd"
 PACKAGECONFIG_remove = "machined hibernate ldconfig binfmt backlight quotacheck localed kdbus ima smack polkit"
 FILESEXTRAPATHS_append := "${THISDIR}/${PN}:"
 SRC_URI += "file://default.network"
+SRC_URI += "file://obmc-standby.target"
 
 FILES_${PN} += "${libdir}/systemd/network/default.network"
+FILES_${PN} += "${systemd_system_unitdir}/obmc-standby.target"
 
 do_install_append() {
         install -m 644 ${WORKDIR}/default.network ${D}${libdir}/systemd/network/
+        install -m 644 ${WORKDIR}/obmc-standby.target ${D}${systemd_system_unitdir}
+        ln -sf ../obmc-standby.target \
+                ${D}${systemd_system_unitdir}/multi-user.target.wants/obmc-standby.target
 
         #TODO Remove after this issue is resolved
         #https://github.com/openbmc/openbmc/issues/152


### PR DESCRIPTION
Add a target pulled in by multi-user to which Phosphor applications
can be added.  This is an organizational change only.

Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/462)
<!-- Reviewable:end -->
