### PR TITLE
add perl regex fix for Automake

### DIFF
--- a/import-layers/yocto-poky/meta/recipes-devtools/automake/automake/perl-regex-curly.patch
+++ b/import-layers/yocto-poky/meta/recipes-devtools/automake/automake/perl-regex-curly.patch
@@ -1,0 +1,26 @@
+From 13f00eb4493c217269b76614759e452d8302955e Mon Sep 17 00:00:00 2001
+From: Paul Eggert <eggert@cs.ucla.edu>
+Date: Thu, 31 Mar 2016 23:35:29 +0000
+Subject: automake: port to Perl 5.22 and later
+
+Without this change, Perl 5.22 complains "Unescaped left brace in
+regex is deprecated" and this is planned to become a hard error in
+Perl 5.26.  See:
+http://search.cpan.org/dist/perl-5.22.0/pod/perldelta.pod#A_literal_%22{%22_should_now_be_escaped_in_a_pattern
+* bin/automake.in (substitute_ac_subst_variables): Escape left brace.
+---
+diff --git a/bin/automake.in b/bin/automake.in
+index a3a0aa3..2c8f31e 100644
+--- a/bin/automake.in
++++ b/bin/automake.in
+@@ -3878,7 +3878,7 @@ sub substitute_ac_subst_variables_worker
+ sub substitute_ac_subst_variables
+ {
+   my ($text) = @_;
+-  $text =~ s/\${([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
++  $text =~ s/\$[{]([^ \t=:+{}]+)}/substitute_ac_subst_variables_worker ($1)/ge;
+   return $text;
+ }
+ 
+--
+cgit v0.9.0.2

--- a/import-layers/yocto-poky/meta/recipes-devtools/automake/automake_1.15.bb
+++ b/import-layers/yocto-poky/meta/recipes-devtools/automake/automake_1.15.bb
@@ -21,6 +21,7 @@ RDEPENDS_${PN}_class-native = "autoconf-native hostperl-runtime-native"
 SRC_URI += " file://python-libdir.patch \
             file://buildtest.patch \
             file://performance.patch \
+            file://perl-regex-curly.patch \
             file://new_rt_path_for_test-driver.patch"
 
 SRC_URI[md5sum] = "716946a105ca228ab545fc37a70df3a3"


### PR DESCRIPTION
Build was failing on Arch Linux due to recent Perl giving error
on unescaped curly braces. Patch fixing it was copied from Arch
Build System.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/openbmc/1816)
<!-- Reviewable:end -->
