### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/meta-phosphor/recipes-phosphor/chassis/files/obmc-phosphor-chassisd.py
+++ b/meta-phosphor/recipes-phosphor/chassis/files/obmc-phosphor-chassisd.py
@@ -16,6 +16,7 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from __future__ import print_function
 import time
 import sys
 import dbus
@@ -23,7 +24,7 @@ import dbus.service
 import dbus.mainloop.glib
 
 if __name__ == '__main__':
-	print "obmc-phosphor-chassisd starting..."
+	print("obmc-phosphor-chassisd starting...")
 
 	while 1:
 		time.sleep(5)

--- a/meta-phosphor/recipes-phosphor/flash/files/obmc-phosphor-flashd.py
+++ b/meta-phosphor/recipes-phosphor/flash/files/obmc-phosphor-flashd.py
@@ -16,6 +16,7 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from __future__ import print_function
 import time
 import sys
 import dbus
@@ -23,7 +24,7 @@ import dbus.service
 import dbus.mainloop.glib
 
 if __name__ == '__main__':
-	print "obmc-phosphor-flashd starting..."
+	print("obmc-phosphor-flashd starting...")
 
 	while 1:
 		time.sleep(5)

--- a/meta-phosphor/recipes-phosphor/system/files/obmc-phosphor-sysd.py
+++ b/meta-phosphor/recipes-phosphor/system/files/obmc-phosphor-sysd.py
@@ -16,6 +16,7 @@
 # implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+from __future__ import print_function
 import time
 import sys
 import dbus
@@ -23,7 +24,7 @@ import dbus.service
 import dbus.mainloop.glib
 
 if __name__ == '__main__':
-	print "obmc-phosphor-watchdogd starting..."
+	print("obmc-phosphor-watchdogd starting...")
 
 	while 1:
 		time.sleep(5)

--- a/poky/bitbake/lib/bb/pysh/pyshyacc.py
+++ b/poky/bitbake/lib/bb/pysh/pyshyacc.py
@@ -7,6 +7,7 @@
 
 """PLY grammar file.
 """
+from __future__ import print_function
 import os.path
 import sys
 
@@ -746,7 +747,7 @@ def print_commands(cmds, output=sys.stdout):
             for c in cmd:
                 print_tree(c, spaces + 3, output)              
         else:
-            print >>output, ' '*spaces + str(cmd)
+            print(' '*spaces + str(cmd), file=output)
     
     formatted = format_commands(cmds)
     print_tree(formatted, 0, output)

--- a/poky/scripts/tiny/ksum.py
+++ b/poky/scripts/tiny/ksum.py
@@ -15,6 +15,7 @@
 # Tom Zanussi <tom.zanussi (at] linux.intel.com>
 #
 
+from __future__ import print_function
 __version__ = "0.1.0"
 
 # Python Standard Library modules
@@ -62,7 +63,7 @@ def is_ko_file(filename):
     return False
 
 def collect_object_files():
-    print "Collecting object files recursively from %s..." % os.getcwd()
+    print("Collecting object files recursively from %s..." % os.getcwd())
     for dirpath, dirs, files in os.walk(os.getcwd()):
         for filename in files:
             if is_ko_file(filename):
@@ -70,7 +71,7 @@ def collect_object_files():
             elif is_vmlinux_file(filename):
                 global vmlinux_file
                 vmlinux_file = os.path.join(dirpath, filename)
-    print "Collecting object files [DONE]"
+    print("Collecting object files [DONE]")
 
 def add_ko_file(filename):
         p = Popen("size -t " + filename, shell=True, stdout=PIPE, stderr=PIPE)
@@ -78,9 +79,9 @@ def add_ko_file(filename):
         if len(output) > 2:
             sizes = output[-1].split()[0:4]
             if verbose:
-                print "     %10d %10d %10d %10d\t" % \
-                    (int(sizes[0]), int(sizes[1]), int(sizes[2]), int(sizes[3])),
-                print "%s" % filename[len(os.getcwd()) + 1:]
+                print("     %10d %10d %10d %10d\t" % \
+                    (int(sizes[0]), int(sizes[1]), int(sizes[2]), int(sizes[3])), end=' ')
+                print("%s" % filename[len(os.getcwd()) + 1:])
             global n_ko_files, ko_text, ko_data, ko_bss, ko_total
             ko_text += int(sizes[0])
             ko_data += int(sizes[1])
@@ -94,9 +95,9 @@ def get_vmlinux_totals():
         if len(output) > 2:
             sizes = output[-1].split()[0:4]
             if verbose:
-                print "     %10d %10d %10d %10d\t" % \
-                    (int(sizes[0]), int(sizes[1]), int(sizes[2]), int(sizes[3])),
-                print "%s" % vmlinux_file[len(os.getcwd()) + 1:]
+                print("     %10d %10d %10d %10d\t" % \
+                    (int(sizes[0]), int(sizes[1]), int(sizes[2]), int(sizes[3])), end=' ')
+                print("%s" % vmlinux_file[len(os.getcwd()) + 1:])
             global vmlinux_text, vmlinux_data, vmlinux_bss, vmlinux_total
             vmlinux_text += int(sizes[0])
             vmlinux_data += int(sizes[1])
@@ -129,20 +130,20 @@ def main():
     sum_ko_files()
     get_vmlinux_totals()
 
-    print "\nTotals:"
-    print "\nvmlinux:"
-    print "    text\tdata\t\tbss\t\ttotal"
-    print "    %-10d\t%-10d\t%-10d\t%-10d" % \
-        (vmlinux_text, vmlinux_data, vmlinux_bss, vmlinux_total)
-    print "\nmodules (%d):" % n_ko_files
-    print "    text\tdata\t\tbss\t\ttotal"
-    print "    %-10d\t%-10d\t%-10d\t%-10d" % \
-        (ko_text, ko_data, ko_bss, ko_total)
-    print "\nvmlinux + modules:"
-    print "    text\tdata\t\tbss\t\ttotal"
-    print "    %-10d\t%-10d\t%-10d\t%-10d" % \
+    print("\nTotals:")
+    print("\nvmlinux:")
+    print("    text\tdata\t\tbss\t\ttotal")
+    print("    %-10d\t%-10d\t%-10d\t%-10d" % \
+        (vmlinux_text, vmlinux_data, vmlinux_bss, vmlinux_total))
+    print("\nmodules (%d):" % n_ko_files)
+    print("    text\tdata\t\tbss\t\ttotal")
+    print("    %-10d\t%-10d\t%-10d\t%-10d" % \
+        (ko_text, ko_data, ko_bss, ko_total))
+    print("\nvmlinux + modules:")
+    print("    text\tdata\t\tbss\t\ttotal")
+    print("    %-10d\t%-10d\t%-10d\t%-10d" % \
         (vmlinux_text + ko_text, vmlinux_data + ko_data, \
-         vmlinux_bss + ko_bss, vmlinux_total + ko_total)
+         vmlinux_bss + ko_bss, vmlinux_total + ko_total))
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.