### PR TITLE
Use more trustworthy fallback NTP and DNS servers

### DIFF
--- a/poky/meta/recipes-core/systemd/systemd_242.bb
+++ b/poky/meta/recipes-core/systemd/systemd_242.bb
@@ -200,7 +200,7 @@ EXTRA_OEMESON += "-Dnobody-user=nobody \
                   "
 		  
 # Fallback to more trustworthy NTP and DNS servers (OpenNIC Anycast and NTP Pool Project)
-EXTRA_OEMESON += "-Ddns-servers=\"185.121.177.177 169.239.202.202\" \
+EXTRA_OEMESON += "-Ddns-servers=\"185.121.177.177 169.239.202.202 2a05:dfc7:5::53 2a05:dfc7:5353::53\" \
                   -Dntp-servers=\"0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org\" \
 		 "
 

--- a/poky/meta/recipes-core/systemd/systemd_242.bb
+++ b/poky/meta/recipes-core/systemd/systemd_242.bb
@@ -198,6 +198,11 @@ EXTRA_OEMESON += "-Dnobody-user=nobody \
                   -Dsysvrcnd-path=${sysconfdir} \
                   -Ddefault-locale=C \
                   "
+		  
+# Fallback to more trustworthy NTP and DNS servers (OpenNIC Anycast and NTP Pool Project)
+EXTRA_OEMESON += "-Ddns-servers=\"185.121.177.177 169.239.202.202\" \
+                  -Dntp-servers=\"0.pool.ntp.org 1.pool.ntp.org 2.pool.ntp.org 3.pool.ntp.org\" \
+		 "
 
 # Hardcode target binary paths to avoid using paths from sysroot
 EXTRA_OEMESON += "-Dkexec-path=${sbindir}/kexec \


### PR DESCRIPTION
Whether it be these specific servers or others, the defaults from systemd create concerns among users. Ideally there should be no fallback at all, but it's non-trivial to patch systemd for this.

Default DNS servers: https://github.com/systemd/systemd/blob/master/meson_options.txt#L223
Default NTP servers: https://github.com/systemd/systemd/blob/master/meson_options.txt#L226

If one controls NTP, it means they can mess with TLS Certificate Validation.
If one controls DNS, it means they can hijack any domain name.
If one controls both NTP and DNS, it means they can both hijack third parties but also fool TLS Certificate Validation, and that has an important impact.