### PR TITLE
Set npm registries to use https rather than http

### DIFF
--- a/poky/bitbake/lib/bb/fetch2/npm.py
+++ b/poky/bitbake/lib/bb/fetch2/npm.py
@@ -142,7 +142,7 @@ class Npm(FetchMethod):
             raise ParameterError("Invalid 'version' parameter", ud.url)
 
         # Extract the 'registry' part of the url
-        ud.registry = re.sub(r"^npm://", "http://", ud.url.split(";")[0])
+        ud.registry = re.sub(r"^npm://", "https://", ud.url.split(";")[0])
 
         # Using the 'downloadfilename' parameter as local filename
         # or the npm package name.


### PR DESCRIPTION
Was building an openbmc image today and noted that it errored out with
the following:

ERROR: nlf-native-2.1.1-r0 do_fetch: Fetcher failure: Fetch command export PSEUDO_DISABLED=1; export DBUS_SESSION_BUS_ADDRESS="unix:path=/run/user/1000/bus"; export SSH_AGENT_PID="202611"; export SSH_AUTH_SOCK="/run/user/1000/keyring/ssh"; export HTTP_PROXY="http://%USER%:%PASSWORD%@%SERVER%:%PORT%"; export PATH="/home/nhorman/git/privafy/openbmc/scripts/native-intercept:/home/nhorman/git/privafy/openbmc/optee/tmp/work/x86_64-linux/nlf-native/2.1.1-r0/recipe-sysroot-native/usr/bin/python3-native:/home/nhorman/git/privafy/openbmc/scripts:/home/nhorman/git/privafy/openbmc/optee/tmp/work/x86_64-linux/nlf-native/2.1.1-r0/recipe-sysroot-native/usr/bin/x86_64-linux:/home/nhorman/git/privafy/openbmc/optee/tmp/work/x86_64-linux/nlf-native/2.1.1-r0/recipe-sysroot-native/usr/bin:/home/nhorman/git/privafy/openbmc/optee/tmp/work/x86_64-linux/nlf-native/2.1.1-r0/recipe-sysroot-native/usr/sbin:/home/nhorman/git/privafy/openbmc/optee/tmp/work/x86_64-linux/nlf-native/2.1.1-r0/recipe-sysroot-native/usr/bin:/home/nhorman/git/privafy/openbmc/optee/tmp/work/x86_64-linux/nlf-native/2.1.1-r0/recipe-sysroot-native/sbin:/home/nhorman/git/privafy/openbmc/optee/tmp/work/x86_64-linux/nlf-native/2.1.1-r0/recipe-sysroot-native/bin:/home/nhorman/git/privafy/openbmc/poky/bitbake/bin:/home/nhorman/git/privafy/openbmc/optee/tmp/hosttools"; export HOME="/tmp/tmp107nd_c3"; NPM_CONFIG_GLOBALCONFIG=/tmp/tmp107nd_c3/npmrc NPM_CONFIG_USERCONFIG=/tmp/tmp107nd_c3/npmrc npm view nlf@2.1.1 failed with exit code 1, output:
{
  "error": {
    "summary": "URI malformed",
    "detail": ""
  }
}

I hadn't altered the nlf package, but some quick experimenting led to
the discoveies that:

1) the npm.py code in poky subs http:// for npm://
2) the npm client doesn't appear to be handling 301 codes properly, so
   instead of just following the redirect, the above error is issued.

I'm not super well versed in nodejs, so I'm not going to be able to
diagnose the npm client in any sort of short time frame, but it seems to
me that, given the fact that the nodejs registry has been https for
ever, it would probably make sense to just update the npm.py code to sub
in https:// fo npm://, which resolved the issue for me:

Signed-off-by: Neil Horman <nhorman@gmail.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
