### PR TITLE
Remove the redundant `bzip2` from the Ubuntu command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ for the latest requirements
 
 ```sh
 sudo apt install git gcc g++ make file wget \
-    gawk diffstat bzip2 cpio chrpath zstd lz4 bzip2
+    gawk diffstat bzip2 cpio chrpath zstd lz4
 ```
 
 #### Fedora


### PR DESCRIPTION
In the Ubuntu command of installing dependency libraries, the library `bzip2` appears twice. Remove one of them.

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
